### PR TITLE
Fix xcpretty swallowing up errors

### DIFF
--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -19,6 +19,7 @@ module XCPretty
     def format_compile(file_name, file_path);                  EMPTY; end
     def format_compile_command(compiler_command, file_path);   EMPTY; end
     def format_compile_storyboard(file_name, file_path);       EMPTY; end
+    def format_compile_storyboard_error(file_name, error);     EMPTY; end
     def format_compile_xib(file_name, file_path);              EMPTY; end
     def format_copy_header_file(source, target);               EMPTY; end
     def format_copy_plist_file(source, target);                EMPTY; end
@@ -34,7 +35,8 @@ module XCPretty
     def format_process_pch(file);                              EMPTY; end
     def format_process_pch_command(file_path);                 EMPTY; end
     def format_phase_success(phase_name);                      EMPTY; end
-    def format_phase_script_execution(script_name);            EMPTY; end
+    def format_phase_script_execution(phase_name);             EMPTY; end
+    def format_phase_script_error(error, output)               EMPTY; end
     def format_process_info_plist(file_name, file_path);       EMPTY; end
     def format_codesign(file);                                 EMPTY; end
     def format_preprocess(file);                               EMPTY; end
@@ -114,9 +116,18 @@ module XCPretty
       "\n#{red(error_symbol + " " + message)}\n\n"
     end
 
+    def format_phase_script_error(error, output)
+      indented_output = output.join("    ")
+      "\n#{red(error_symbol + " ")}#{error}: #{red(indented_output)}\n\n"
+    end
+
     def format_compile_error(file, file_path, reason, line, cursor)
       "\n#{red(error_symbol + " ")}#{file_path}: #{red(reason)}\n\n" \
         "#{line}\n#{cyan(cursor)}\n\n"
+    end
+
+    def format_compile_storyboard_error(file_name, error)
+      format_error(file_name + ": " + error)
     end
 
     def format_file_missing_error(reason, file_path)

--- a/lib/xcpretty/formatters/simple.rb
+++ b/lib/xcpretty/formatters/simple.rb
@@ -98,8 +98,8 @@ module XCPretty
       format(phase_name.capitalize, "Succeeded")
     end
 
-    def format_phase_script_execution(script_name)
-      format("Running script", "'#{script_name}'")
+    def format_phase_script_execution(phase_name)
+      format("Running phase", "'#{phase_name}'")
     end
 
     def format_process_info_plist(file_name, file_path)

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -127,6 +127,12 @@ TiffUtil eye_icon.tiff
     cd /Users/musalj/code/OSS/Alcatraz
     /usr/bin/tiffutil -cathidpicheck /Users/musalj/code/OSS/Alcatraz/Alcatraz/eye_icon@2x.png /Users/musalj/code/OSS/Alcatraz/Alcatraz/eye_icon.png -out /Users/musalj/Library/Application\ Support/Developer/Shared/Xcode/Plug-ins/Alcatraz.xcplugin/Contents/Resources/eye_icon.tiff
 )
+SAMPLE_RUN_SCRIPT_ERROR = %Q(
+PhaseScriptExecution Run\\ Script DerivedData/Build/Intermediates/Blah.build/Debug-iphonesimulator/Blah.build/Script-F07128051BCF177900851764.sh
+cd /Users/blah/iosapps/test/iOS
+/bin/sh -c /Users/blah/iosapps/test/iOS/DerivedData/Build/Intermediates/Blah.build/Debug-iphonesimulator/Blah.build/Script-F07128051BCF177900851764.sh
+/bin/sh: blah: No such file or directory
+)
 SAMPLE_RUN_SCRIPT = %Q(
 PhaseScriptExecution Check\\ Pods\\ Manifest.lock /Users/musalj/Library/Developer/Xcode/DerivedData/ObjectiveSugar-ayzdhqmmwtqgysdpznmovjlupqjy/Build/Intermediates/ObjectiveSugar.build/Debug-iphonesimulator/ObjectiveSugar.build/Script-468DABF301EC4EC1A00CC4C2.sh
     cd /Users/musalj/code/OSS/ObjectiveSugar/Example
@@ -461,6 +467,7 @@ PhaseScriptExecution Check\\ Pods\\ Manifest.lock /Users/musalj/Library/Develope
     setenv variant normal
     /bin/sh -c /Users/musalj/Library/Developer/Xcode/DerivedData/ObjectiveSugar-ayzdhqmmwtqgysdpznmovjlupqjy/Build/Intermediates/ObjectiveSugar.build/Debug-iphonesimulator/ObjectiveSugar.build/Script-468DABF301EC4EC1A00CC4C2.sh
 )
+
 SAMPLE_ANALYZE = %Q(
 Analyze CocoaChip/CCChip8DisplayView.m
     cd /Users/dustin/Source/CocoaChip
@@ -484,6 +491,9 @@ CompileStoryboard sample/Main.storyboard
     cd /Users/chipp/Developer/sample
     export XCODE_DEVELOPER_USR_PATH=/Applications/Xcode.app/Contents/Developer/usr/bin/..
     /Applications/Xcode.app/Contents/Developer/usr/bin/ibtool --target-device iphone --target-device ipad --errors --warnings --notices --module sample --minimum-deployment-target 7.0 --output-partial-info-plist /Users/chipp/Library/Developer/Xcode/DerivedData/sample-etjztiverddwaddrudeteewjzfxw/Build/Intermediates/ArchiveIntermediates/sample/IntermediateBuildFilesPath/sample.build/Release-iphoneos/sample.build/SJMetroPickerStoryboard-SBPartialInfo.plist --auto-activate-custom-fonts --output-format human-readable-text --compilation-directory /Users/chipp/Library/Developer/Xcode/DerivedData/sample-etjztiverddwaddrudeteewjzfxw/Build/Intermediates/ArchiveIntermediates/sample/InstallationBuildProductsLocation/Applications/sample.app /Users/chipp/Developer/sample/sample/Main.storyboard
+)
+SAMPLE_COMPILE_STORYBOARD_ERROR = %Q(
+/Users/blah/iosapps/test/blah-Blah-ios/Blah/Resources/Views/LaunchScreen.storyboard: error: Line 11: error parsing attribute name
 )
 SAMPLE_CODESIGN = %Q(
 CodeSign build/Release/CocoaChip.app

--- a/spec/xcpretty/formatters/simple_spec.rb
+++ b/spec/xcpretty/formatters/simple_spec.rb
@@ -120,7 +120,7 @@ module XCPretty
 
       it "formats Phase Script Execution" do
         @formatter.format_phase_script_execution("Check Pods Manifest.lock").should ==
-        "> Running script 'Check Pods Manifest.lock'"
+        "> Running phase 'Check Pods Manifest.lock'"
       end
 
       it "formats precompiling output" do

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -111,6 +111,11 @@ module XCPretty
       @parser.parse(SAMPLE_COMPILE_STORYBOARD)
     end
 
+    it "parses compiling storyboard errors" do
+      @formatter.should receive(:format_compile_storyboard_error).with("LaunchScreen.storyboard", "Line 11: error parsing attribute name")
+      @parser.parse(SAMPLE_COMPILE_STORYBOARD_ERROR)
+    end
+
     it 'parses CopyPlistFile' do
       @formatter.should receive(:format_copy_plist_file).with(
         '/path/to/Some.plist', '/some other/File.plist')
@@ -214,8 +219,21 @@ module XCPretty
     end
 
     it "parses PhaseScriptExecution" do
-      @formatter.should receive(:format_phase_script_execution).with('Check Pods Manifest.lock')
+      @formatter.should receive(:format_phase_script_execution).with('Check Pods Manifest.lock /Users/musalj/Library/Developer/Xcode/DerivedData/ObjectiveSugar-ayzdhqmmwtqgysdpznmovjlupqjy/Build/Intermediates/ObjectiveSugar.build/Debug-iphonesimulator/ObjectiveSugar.build/Script-468DABF301EC4EC1A00CC4C2.sh')
       @parser.parse(SAMPLE_RUN_SCRIPT)
+    end
+
+    it "parses PhaseScriptExecution Error" do
+      @formatter.should receive(:format_phase_script_execution).with('Run Script DerivedData/Build/Intermediates/Blah.build/Debug-iphonesimulator/Blah.build/Script-F07128051BCF177900851764.sh')
+      @formatter.should receive(:format_phase_script_error).with('/bin/sh: blah: No such file or directory',
+                                                                 ['PhaseScriptExecution Run\\ Script DerivedData/Build/Intermediates/Blah.build/Debug-iphonesimulator/Blah.build/Script-F07128051BCF177900851764.sh',
+                                                                  'cd /Users/blah/iosapps/test/iOS',
+                                                                  '/bin/sh -c /Users/blah/iosapps/test/iOS/DerivedData/Build/Intermediates/Blah.build/Debug-iphonesimulator/Blah.build/Script-F07128051BCF177900851764.sh',
+                                                                  '/bin/sh: blah: No such file or directory'])
+
+      SAMPLE_RUN_SCRIPT_ERROR.each_line do |line|
+        @parser.parse(line.chomp)
+      end
     end
 
     it "parses process PCH" do
@@ -447,6 +465,11 @@ module XCPretty
         end
         @formatter.should_not receive(:format_compile_error)
         @parser.parse("hohohoooo")
+      end
+
+      it 'parses generic errors' do
+        @formatter.should receive(:format_error).with("Hi there. I'm a really nasty error. Can you fix me")
+        @parser.parse("   error: Hi there. I'm a really nasty error. Can you fix me")
       end
     end
 


### PR DESCRIPTION
We are a growing CI solution for iOS apps and are gladly using xcpretty.
That said, we have found instances where xcpretty is swallowing up errors making our end users lives rather unpleasant.

For phase script execution:
a. The regular expression was invalid due to incorrect assumptions about script paths (expecting absolute path, when xcode can provide a relative path) (for which test was added).
b. There was no output to be able to diagnose the issue if an error is present (for which test was added)
Resultantly, we actually store the script output for the last phase script run, and spit it out on error. 
This has helped us tremendously in the past in figuring out why a script was failing...

For Compile Storyboards:
a. There was no output to determine why compilation failed. (for which test was added)

For Generic Errors
a. We should be spitting out generic errors. (for which test was added)
