### PR TITLE
Fix issues with catching warnings (in particular important code sign …

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -193,7 +193,7 @@ module XCPretty
 
       # @regex Captured groups
       # $1 = whole warning
-      GENERIC_WARNING_MATCHER = /^warning:\s(.*)$/
+      GENERIC_WARNING_MATCHER = /warning:\s(.*)$/
     end
 
     module Errors
@@ -204,6 +204,10 @@ module XCPretty
       # @regex Captured groups
       # $1 = whole error
       CODESIGN_ERROR_MATCHER = /^(Code\s?Sign error:.*)$/
+
+      # @regex Captured groups
+      # $1 = whole error
+      CODESIGN_WARNING_MATCHER = /^(Code\s?Sign warning:.*)$/
 
       # @regex Captured groups
       # $1 = file_path
@@ -299,6 +303,8 @@ module XCPretty
         formatter.format_codesign($1)
       when CODESIGN_ERROR_MATCHER
         formatter.format_error($1)
+      when CODESIGN_WARNING_MATCHER
+        formatter.format_warning($1)
       when COMPILE_MATCHER
         formatter.format_compile($2, $1)
       when COMPILE_COMMAND_MATCHER

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -530,6 +530,15 @@ SAMPLE_FILE_MISSING_ERROR = %Q(
 <unknown>:0: error: no such file or directory: '/Users/travis/build/supermarin/project/Classes/Class + Category/Two Words/MissingViewController.swift'
 )
 
+SAMPLE_CODESIGN_WARNING = %Q(
+Code Sign warning: Specified PROVISIONING_PROFILE (blah) not found and no CODE_SIGN_IDENTITY specified. Ignoring PROVISIONING_PROFILE for now. This will become an error in the future.
+)
+
+SAMPLE_CODESIGN_WARNING_NO_SPACES = %Q(
+CodeSign warning: Specified PROVISIONING_PROFILE (blah) not found and no CODE_SIGN_IDENTITY specified. Ignoring PROVISIONING_PROFILE for now. This will become an error in the future.
+)
+
+
 SAMPLE_CODESIGN_ERROR = %Q(
 Code Sign error: No code signing identites found: No valid signing identities (i.e. certificate and private key pair) matching the team ID ‚ÄúCAT6HF57NJ‚Äù were found.
 )

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -420,6 +420,21 @@ module XCPretty
         @parser.parse(SAMPLE_CODESIGN_ERROR)
       end
 
+
+      it "parses code sign warning:" do
+        @formatter.should receive(:format_warning).with(
+          'Code Sign warning: Specified PROVISIONING_PROFILE (blah) not found and no CODE_SIGN_IDENTITY specified. Ignoring PROVISIONING_PROFILE for now. This will become an error in the future.'
+        )
+        @parser.parse(SAMPLE_CODESIGN_WARNING)
+      end
+
+      it "parses code sign warning: (no spaces)" do
+      @formatter.should receive(:format_warning).with(
+        'CodeSign warning: Specified PROVISIONING_PROFILE (blah) not found and no CODE_SIGN_IDENTITY specified. Ignoring PROVISIONING_PROFILE for now. This will become an error in the future.'
+      )
+      @parser.parse(SAMPLE_CODESIGN_WARNING_NO_SPACES)
+      end
+
       it "parses CodeSign error: (no spaces)" do
         @formatter.should receive(:format_error).with(
           "CodeSign error: code signing is required for product type 'Application' in SDK 'iOS 7.0'"


### PR DESCRIPTION
…warnings)

Added a code sign warning catcher (with tests)
The generic warning catcher is a bit too strict on the regex.
