### PR TITLE
Use String#scrub when parse.

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'string/scrub' if RUBY_VERSION.to_f < 2.1
 
 module XCPretty
 
@@ -301,6 +302,7 @@ module XCPretty
     end
 
     def parse(text)
+      text = text.scrub('')
       update_test_state(text)
       update_error_state(text)
       update_linker_failure_state(text)

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -65,6 +65,7 @@ Clean.Remove clean /Users/musalj/Library/Developer/Xcode/DerivedData/ObjectiveSu
 SAMPLE_EXECUTED_TESTS = "Executed 4 tests, with 0 failures (0 unexpected) in 0.003 (0.004) seconds"
 SAMPLE_SPECTA_EXECUTED_TESTS = "       Executed 4 tests, with 0 failures (0 unexpected) in 10.192 (10.193) seconds"
 SAMPLE_OCUNIT_TEST = "Test Case '-[RACCommandSpec enabled_signal_should_send_YES_while_executing_is_YES]' passed (0.001 seconds)."
+SAMPLE_OCUNIT_TEST_WITH_INVALID_BYTE_SEQUENCE = "Test Case '-[RACCommandSpec enabled_signal_should_send_YES\x81_while_executing_is_YES]' passed (0.001 seconds)."
 SAMPLE_SPECTA_TEST = "         Test Case '-[SKWelcomeActivationViewControllerSpecSpec SKWelcomeActivationViewController_When_a_user_enters_their_details_lets_them_enter_a_valid_manager_code]' passed (0.725 seconds)."
 SAMPLE_SLOWISH_TEST = "Test Case '-[RACCommandSpec enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES]' passed (0.026 seconds)."
 SAMPLE_SLOW_TEST = "Test Case '-[RACCommandSpec enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES]' passed (0.101 seconds)."

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -206,6 +206,13 @@ module XCPretty
       @parser.parse(SAMPLE_OCUNIT_TEST)
     end
 
+    it "parses passing ocunit tests, but include invalid byte sequence" do
+      @formatter.should receive(:format_passing_test).with('RACCommandSpec',
+                                                           'enabled_signal_should_send_YES_while_executing_is_YES',
+                                                           '0.001')
+      @parser.parse(SAMPLE_OCUNIT_TEST_WITH_INVALID_BYTE_SEQUENCE)
+    end
+
     it "parses passing specta tests" do
       @formatter.should receive(:format_passing_test).with('SKWelcomeActivationViewControllerSpecSpec',
                                                            'SKWelcomeActivationViewController_When_a_user_enters_their_details_lets_them_enter_a_valid_manager_code',

--- a/xcpretty.gemspec
+++ b/xcpretty.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'rouge', '~> 2.0.7'
+  spec.add_dependency 'string-scrub', '~> 0.1.1' if RUBY_VERSION.to_f < 2.1
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I executed the following command.
```
set -o pipefail && xcodebuild test -configuration "Local" -workspace "myapp.xcworkspace" -scheme "myappTests" -destination "name=iPhone 7" | tee '/var/folders/90/5stft2v13fb_m_gv3c8x9nwc0000gn/T/fastlane_logs163335064/fastlane/xcbuild/2017-06-29/2152/xcodebuild.log' | xcpretty --color --test
```

it output the following log.
```
Test Case '-[myappTests.BankEditViewPresenterAccountTypeTests test_SegmentIndexが0の時<E3><81>** TEST SUCCEEDED **

<AB>普通預金口座のAccountTypeが返ること]' started.
```

Passing this log to xcpretty gives the following error.
```
ArgumentError: invalid byte sequence in UTF-8
  /Users/hisaichi5518/myapp/vendor/bundle/ruby/2.4.0/gems/xcpretty-0.2.8/lib/xcpretty/parser.rb:429:in `==='
  /Users/hisaichi5518/myapp/ios/vendor/bundle/ruby/2.4.0/gems/xcpretty-0.2.8/lib/xcpretty/parser.rb:429:in `update_test_state'
  /Users/hisaichi5518/myapp/vendor/bundle/ruby/2.4.0/gems/xcpretty-0.2.8/lib/xcpretty/parser.rb:304:in `parse'
  /Users/hisaichi5518/myapp/vendor/bundle/ruby/2.4.0/gems/xcpretty-0.2.8/lib/xcpretty/formatters/formatter.rb:87:in `pretty_format'
  /Users/hisaichi5518/myapp/vendor/bundle/ruby/2.4.0/gems/xcpretty-0.2.8/lib/xcpretty/printer.rb:19:in `pretty_print'
  /Users/hisaichi5518/myapp/vendor/bundle/ruby/2.4.0/gems/xcpretty-0.2.8/bin/xcpretty:84:in `block in <top (required)>'
  /Users/hisaichi5518/myapp/vendor/bundle/ruby/2.4.0/gems/xcpretty-0.2.8/bin/xcpretty:83:in `each_line'
  /Users/hisaichi5518/myapp/vendor/bundle/ruby/2.4.0/gems/xcpretty-0.2.8/bin/xcpretty:83:in `<top (required)>'
  /Users/hisaichi5518/myapp/vendor/bundle/ruby/2.4.0/bin/xcpretty:22:in `load'
  /Users/hisaichi5518/myapp/vendor/bundle/ruby/2.4.0/bin/xcpretty:22:in `<top (required)>'
```

So, I want to use String#scrub when parse.