### PR TITLE
Add initial support for parallel test output

### DIFF
--- a/assets/report.html.erb
+++ b/assets/report.html.erb
@@ -137,7 +137,12 @@
                     <h3 class="time"><%= test[:time] %>s</h3>
                   <% end %>
                 </td>
-                <td><h3 class="title"><%= test[:name] %></h3></td>
+                <td>
+                  <% if test[:device] %>
+                    <h3 class="title"><%= test[:name] %> (<%= test[:device] %>)</h3></td>
+                  <% else %>
+                    <h3 class="title"><%= test[:name] %></h3></td>
+                  <% end %>
               </tr>
               <% if test[:reason] || test[:snippet] || !test[:screenshots].empty? %>
                 <tr class="details <%= test[:failing] ? 'failing' : 'passing'%> <%= detail_class %>">

--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -30,10 +30,11 @@ module XCPretty
     def format_generate_dsym(dsym);                            EMPTY; end
     def format_linking(file, build_variant, arch);             EMPTY; end
     def format_libtool(library);                               EMPTY; end
-    def format_passing_test(suite, test, device, time);        EMPTY; end
-    def format_pending_test(suite, test, device);              EMPTY; end
+    def format_passing_device_test(suite, test, time, device); EMPTY; end
+    def format_pending_device_test(suite, test, device);       EMPTY; end
     def format_measuring_test(suite, test, time);              EMPTY; end
-    def format_failing_test(suite, test, device, reason, file_path); EMPTY; end
+    def format_failing_device_test(suite, test, reason,
+                                   file_path, device);         EMPTY; end
     def format_process_pch(file);                              EMPTY; end
     def format_process_pch_command(file_path);                 EMPTY; end
     def format_phase_success(phase_name);                      EMPTY; end
@@ -43,9 +44,9 @@ module XCPretty
     def format_preprocess(file);                               EMPTY; end
     def format_pbxcp(file);                                    EMPTY; end
     def format_shell_command(command, arguments);              EMPTY; end
-    def format_test_run_started(name, device);                 EMPTY; end
+    def format_device_test_run_started(name, device);          EMPTY; end
     def format_test_run_finished(name, time);                  EMPTY; end
-    def format_test_suite_started(name, device);               EMPTY; end
+    def format_device_test_suite_started(name, device);        EMPTY; end
     def format_test_summary(message, failures_per_suite);      EMPTY; end
     def format_touch(file_path, file_name);                    EMPTY; end
     def format_tiffutil(file);                                 EMPTY; end
@@ -66,12 +67,20 @@ module XCPretty
     #       the same for warnings
     def format_compile_warning(file_name, file_path, reason,
                                line, cursor);                  EMPTY; end
+
+    # DEPRECATED
+    def format_passing_test(suite, test, time);                EMPTY; end
+    def format_pending_test(suite, test);                      EMPTY; end
+    def format_failing_test(suite, test, reason, file_path);   EMPTY; end
+    def format_test_run_started(name);                         EMPTY; end
+    def format_test_suite_started(name);                       EMPTY; end
   end
 
   class Formatter
 
     include ANSI
     include FormatMethods
+    extend Gem::Deprecate
 
     attr_reader :parser
 
@@ -154,6 +163,35 @@ module XCPretty
       "#{yellow(warning_symbol + " " + message)}"
     end
 
+    # Backwards Compatibility / Deprecated Methods
+
+    def format_passing_device_test(suite, test, time, device)
+      format_passing_test(suite, test, time)
+    end
+
+    def format_pending_device_test(suite, test, device)
+      format_pending_test(suite, test)
+    end
+
+    def format_failing_device_test(suite, test, reason,  file_path, device)
+      format_failing_test(suite, test, reason,  file_path)
+    end
+
+    def format_device_test_run_started(name, device)
+      format_test_run_started(name)
+    end
+
+    def format_device_test_suite_started(name, device)
+      format_test_suite_started(name)
+    end
+
+    deprecate :format_passing_test, :format_passing_device_test, 2017, 10
+    deprecate :format_pending_test, :format_pending_device_test, 2017, 10
+    deprecate :format_failing_test, :format_failing_device_test, 2017, 10
+    deprecate :format_test_run_started,
+              :format_device_test_run_started, 2017, 10
+    deprecate :format_test_suite_started,
+              :format_device_test_suite_started, 2017, 10
 
     private
 

--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -25,13 +25,15 @@ module XCPretty
     def format_copy_plist_file(source, target);                EMPTY; end
     def format_copy_strings_file(file_name);                   EMPTY; end
     def format_cpresource(file);                               EMPTY; end
+    def format_device_tests_failed(device)                     EMPTY; end
+    def format_device_tests_passed(device)                     EMPTY; end
     def format_generate_dsym(dsym);                            EMPTY; end
     def format_linking(file, build_variant, arch);             EMPTY; end
     def format_libtool(library);                               EMPTY; end
-    def format_passing_test(suite, test, time);                EMPTY; end
-    def format_pending_test(suite, test);                      EMPTY; end
+    def format_passing_test(suite, test, device, time);        EMPTY; end
+    def format_pending_test(suite, test, device);              EMPTY; end
     def format_measuring_test(suite, test, time);              EMPTY; end
-    def format_failing_test(suite, test, reason, file_path);   EMPTY; end
+    def format_failing_test(suite, test, device, reason, file_path); EMPTY; end
     def format_process_pch(file);                              EMPTY; end
     def format_process_pch_command(file_path);                 EMPTY; end
     def format_phase_success(phase_name);                      EMPTY; end
@@ -41,9 +43,9 @@ module XCPretty
     def format_preprocess(file);                               EMPTY; end
     def format_pbxcp(file);                                    EMPTY; end
     def format_shell_command(command, arguments);              EMPTY; end
-    def format_test_run_started(name);                         EMPTY; end
+    def format_test_run_started(name, device);                 EMPTY; end
     def format_test_run_finished(name, time);                  EMPTY; end
-    def format_test_suite_started(name);                       EMPTY; end
+    def format_test_suite_started(name, device);               EMPTY; end
     def format_test_summary(message, failures_per_suite);      EMPTY; end
     def format_touch(file_path, file_name);                    EMPTY; end
     def format_tiffutil(file);                                 EMPTY; end

--- a/lib/xcpretty/formatters/knock.rb
+++ b/lib/xcpretty/formatters/knock.rb
@@ -5,13 +5,16 @@ module XCPretty
     FAIL = 'not ok'
     PASS = 'ok'
 
-    def format_passing_test(suite, test_case, time)
-      "#{PASS} - #{test_case}"
+    def format_passing_test(suite, test_case, device, time)
+      "#{PASS} - #{format_test_description(test_case, device)}"
     end
 
-    def format_failing_test(test_suite, test_case, reason, file)
-      "#{FAIL} - #{test_case}: FAILED" +
-      format_failure_diagnostics(test_suite, test_case, reason, file)
+    def format_failing_test(test_suite, test_case, device, reason, file)
+      knock_result = "#{FAIL} - #{format_test_description(test_case, device)}: FAILED"
+      if reason.nil? || reason.empty? || file.nil? || file.empty?
+        return knock_result
+      end
+      knock_result + format_failure_diagnostics(test_suite, test_case, reason, file)
     end
 
     def format_test_summary(executed_message, failures_per_suite)
@@ -27,6 +30,14 @@ module XCPretty
 
     def format_diagnostics(text)
       "\n# #{text}"
+    end
+
+    def format_test_description(test_case, device)
+      if device.nil? || device.empty?
+        test_case
+      else
+        "#{test_case} on #{device}"
+      end
     end
 
   end

--- a/lib/xcpretty/formatters/knock.rb
+++ b/lib/xcpretty/formatters/knock.rb
@@ -10,11 +10,13 @@ module XCPretty
     end
 
     def format_failing_test(test_suite, test_case, device, reason, file)
-      knock_result = "#{FAIL} - #{format_test_description(test_case, device)}: FAILED"
+      knock_result =
+      "#{FAIL} - #{format_test_description(test_case, device)}: FAILED"
       if reason.nil? || reason.empty? || file.nil? || file.empty?
         return knock_result
       end
-      knock_result + format_failure_diagnostics(test_suite, test_case, reason, file)
+      knock_result +
+      format_failure_diagnostics(test_suite, test_case, reason, file)
     end
 
     def format_test_summary(executed_message, failures_per_suite)

--- a/lib/xcpretty/formatters/knock.rb
+++ b/lib/xcpretty/formatters/knock.rb
@@ -12,7 +12,7 @@ module XCPretty
     def format_failing_test(test_suite, test_case, device, reason, file)
       knock_result =
       "#{FAIL} - #{format_test_description(test_case, device)}: FAILED"
-      if reason.nil? || reason.empty? || file.nil? || file.empty?
+      if reason.to_s.empty? || file.to_s.empty?
         return knock_result
       end
       knock_result +
@@ -35,7 +35,7 @@ module XCPretty
     end
 
     def format_test_description(test_case, device)
-      if device.nil? || device.empty?
+      if device.to_s.empty?
         test_case
       else
         "#{test_case} on #{device}"

--- a/lib/xcpretty/formatters/knock.rb
+++ b/lib/xcpretty/formatters/knock.rb
@@ -5,11 +5,11 @@ module XCPretty
     FAIL = 'not ok'
     PASS = 'ok'
 
-    def format_passing_test(suite, test_case, device, time)
+    def format_passing_device_test(suite, test_case, time, device)
       "#{PASS} - #{format_test_description(test_case, device)}"
     end
 
-    def format_failing_test(test_suite, test_case, device, reason, file)
+    def format_failing_device_test(test_suite, test_case, reason, file, device)
       knock_result =
       "#{FAIL} - #{format_test_description(test_case, device)}: FAILED"
       if reason.to_s.empty? || file.to_s.empty?

--- a/lib/xcpretty/formatters/rspec.rb
+++ b/lib/xcpretty/formatters/rspec.rb
@@ -19,7 +19,7 @@ module XCPretty
       red(FAIL)
     end
 
-    def format_pending_test(suite, test_case)
+    def format_pending_test(suite, test_case, device)
       yellow(PENDING)
     end
 

--- a/lib/xcpretty/formatters/rspec.rb
+++ b/lib/xcpretty/formatters/rspec.rb
@@ -11,11 +11,11 @@ module XCPretty
       ''
     end
 
-    def format_passing_test(suite, test_case, time)
+    def format_passing_test(suite, test_case, device, time)
       green(PASS)
     end
 
-    def format_failing_test(test_suite, test_case, reason, file)
+    def format_failing_test(test_suite, test_case, device, reason, file)
       red(FAIL)
     end
 

--- a/lib/xcpretty/formatters/rspec.rb
+++ b/lib/xcpretty/formatters/rspec.rb
@@ -11,15 +11,15 @@ module XCPretty
       ''
     end
 
-    def format_passing_test(suite, test_case, device, time)
+    def format_passing_device_test(suite, test_case, time, device)
       green(PASS)
     end
 
-    def format_failing_test(test_suite, test_case, device, reason, file)
+    def format_failing_device_test(test_suite, test_case, reason, file, device)
       red(FAIL)
     end
 
-    def format_pending_test(suite, test_case, device)
+    def format_pending_device_test(suite, test_case, device)
       yellow(PENDING)
     end
 

--- a/lib/xcpretty/formatters/simple.rb
+++ b/lib/xcpretty/formatters/simple.rb
@@ -87,7 +87,7 @@ module XCPretty
       format("Linking", target)
     end
 
-    def format_failing_test(suite, test_case, device, reason, file)
+    def format_failing_device_test(suite, test_case, reason, file, device)
       test_description = test_case
       unless device.to_s.empty?
         test_description = "#{test_description} (#{colored_device(device)})"
@@ -98,7 +98,7 @@ module XCPretty
       INDENT + format_test(test_description, :fail)
     end
 
-    def format_passing_test(suite, test_case, device, time)
+    def format_passing_device_test(suite, test_case, time, device)
       time = colored_time(time)
       if device.to_s.empty?
         INDENT +
@@ -110,7 +110,7 @@ module XCPretty
       end
     end
 
-    def format_pending_test(suite, test_case, device)
+    def format_pending_device_test(suite, test_case, device)
       if device.to_s.empty?
         INDENT + format_test("#{test_case} [PENDING]", :pending)
       else
@@ -153,7 +153,7 @@ module XCPretty
       format("Copying", file)
     end
 
-    def format_test_run_started(name, device)
+    def format_device_test_run_started(name, device)
       if device.to_s.empty?
         heading("Test Suite", name, "started")
       else
@@ -164,7 +164,7 @@ module XCPretty
       end
     end
 
-    def format_test_suite_started(name, device)
+    def format_device_test_suite_started(name, device)
       if device.to_s.empty?
         heading("", name, "")
       else

--- a/lib/xcpretty/formatters/simple.rb
+++ b/lib/xcpretty/formatters/simple.rb
@@ -89,17 +89,13 @@ module XCPretty
 
     def format_failing_test(suite, test_case, device, reason, file)
       test_description = test_case
-      if !device.to_s.empty?
-        test_description = "#{test_description} (#{colored_device(device)})"
-      end
-      if !reason.to_s.empty?
-        test_description = "#{test_description}, #{reason}"
-      end
+      test_description = "#{test_description} (#{colored_device(device)})" unless device.to_s.empty?
+      test_description = "#{test_description}, #{reason}" unless reason.to_s.empty?
       INDENT + format_test(test_description, :fail)
     end
 
     def format_passing_test(suite, test_case, device, time)
-      if device.nil? || device.empty?
+      if device.to_s.empty?
         INDENT + format_test("#{test_case} (#{colored_time(time)} seconds)", :pass)
       else
         INDENT + format_test("#{test_case} (#{colored_device(device)}) (#{colored_time(time)} seconds)", :pass)
@@ -107,7 +103,7 @@ module XCPretty
     end
 
     def format_pending_test(suite, test_case, device)
-      if device.nil? || device.empty?
+      if device.to_s.empty?
         INDENT + format_test("#{test_case} [PENDING]", :pending)
       else
         INDENT + format_test("#{test_case} (#{colored_device(device)}) [PENDING]", :pending)
@@ -149,7 +145,7 @@ module XCPretty
     end
 
     def format_test_run_started(name, device)
-      if device.nil? || device.empty?
+      if device.to_s.empty?
         heading("Test Suite", name, "started")
       else
         [heading("Test Suite", name, "started"), "(#{colored_device(device)})"].join(" ").strip
@@ -157,7 +153,7 @@ module XCPretty
     end
 
     def format_test_suite_started(name, device)
-      if device.nil? || device.empty?
+      if device.to_s.empty?
         heading("", name, "")
       else
         [heading("", name, ""), "(#{colored_device(device)})"].join(" ").strip

--- a/lib/xcpretty/formatters/simple.rb
+++ b/lib/xcpretty/formatters/simple.rb
@@ -89,16 +89,24 @@ module XCPretty
 
     def format_failing_test(suite, test_case, device, reason, file)
       test_description = test_case
-      test_description = "#{test_description} (#{colored_device(device)})" unless device.to_s.empty?
-      test_description = "#{test_description}, #{reason}" unless reason.to_s.empty?
+      unless device.to_s.empty?
+        test_description = "#{test_description} (#{colored_device(device)})"
+      end
+      unless reason.to_s.empty?
+        test_description = "#{test_description}, #{reason}"
+      end
       INDENT + format_test(test_description, :fail)
     end
 
     def format_passing_test(suite, test_case, device, time)
+      time = colored_time(time)
       if device.to_s.empty?
-        INDENT + format_test("#{test_case} (#{colored_time(time)} seconds)", :pass)
+        INDENT +
+        format_test("#{test_case} (#{time} seconds)", :pass)
       else
-        INDENT + format_test("#{test_case} (#{colored_device(device)}) (#{colored_time(time)} seconds)", :pass)
+        device = colored_device(device)
+        INDENT +
+        format_test("#{test_case} (#{device}) (#{time} seconds)", :pass)
       end
     end
 
@@ -106,7 +114,8 @@ module XCPretty
       if device.to_s.empty?
         INDENT + format_test("#{test_case} [PENDING]", :pending)
       else
-        INDENT + format_test("#{test_case} (#{colored_device(device)}) [PENDING]", :pending)
+        device = colored_device(device)
+        INDENT + format_test("#{test_case} (#{device}) [PENDING]", :pending)
       end
     end
 
@@ -148,7 +157,10 @@ module XCPretty
       if device.to_s.empty?
         heading("Test Suite", name, "started")
       else
-        [heading("Test Suite", name, "started"), "(#{colored_device(device)})"].join(" ").strip
+        [
+          heading("Test Suite", name, "started"),
+          "(#{colored_device(device)})"
+        ].join(" ").strip
       end
     end
 

--- a/lib/xcpretty/formatters/tap.rb
+++ b/lib/xcpretty/formatters/tap.rb
@@ -17,7 +17,7 @@ module XCPretty
     def format_failing_test(test_suite, test_case, device, reason, file)
       increment_counter
       tap_result = "#{FAIL} #{counter} - #{format_test_description(test_case, device)}"
-      if reason.nil? || reason.empty? || file.nil? || file.empty?
+      if reason.to_s.empty? || file.to_s.empty?
         return tap_result
       end
       tap_result + format_failure_diagnostics(test_suite, test_case, reason, file)
@@ -35,11 +35,9 @@ module XCPretty
     private
 
     def format_test_description(test_case, device)
-      if device.nil? || device.empty?
-        test_case
-      else
-        "#{test_case} on #{device}"
-      end
+      test_description = test_case
+      test_description = "#{test_description} on #{device}" unless device.to_s.empty?
+      test_description
     end
 
     def increment_counter

--- a/lib/xcpretty/formatters/tap.rb
+++ b/lib/xcpretty/formatters/tap.rb
@@ -9,12 +9,12 @@ module XCPretty
       @counter = 0
     end
 
-    def format_passing_test(suite, test_case, device, time)
+    def format_passing_device_test(suite, test_case, time, device)
       increment_counter
       "#{PASS} #{counter} - #{format_test_description(test_case, device)}"
     end
 
-    def format_failing_test(test_suite, test_case, device, reason, file)
+    def format_failing_device_test(test_suite, test_case, reason, file, device)
       increment_counter
       test_description = format_test_description(test_case, device)
       tap_result = "#{FAIL} #{counter} - #{test_description}"
@@ -25,7 +25,7 @@ module XCPretty
       format_failure_diagnostics(test_suite, test_case, reason, file)
     end
 
-    def format_pending_test(test_suite, test_case, device)
+    def format_pending_device_test(test_suite, test_case, device)
       increment_counter
       test_description = format_test_description(test_case, device)
       "#{FAIL} #{counter} - #{test_description} # TODO Not written yet"

--- a/lib/xcpretty/formatters/tap.rb
+++ b/lib/xcpretty/formatters/tap.rb
@@ -9,20 +9,23 @@ module XCPretty
       @counter = 0
     end
 
-    def format_passing_test(suite, test_case, time)
+    def format_passing_test(suite, test_case, device, time)
       increment_counter
-      "#{PASS} #{counter} - #{test_case}"
+      "#{PASS} #{counter} - #{format_test_description(test_case, device)}"
     end
 
-    def format_failing_test(test_suite, test_case, reason, file)
+    def format_failing_test(test_suite, test_case, device, reason, file)
       increment_counter
-      "#{FAIL} #{counter} - #{test_case}" +
-      format_failure_diagnostics(test_suite, test_case, reason, file)
+      tap_result = "#{FAIL} #{counter} - #{format_test_description(test_case, device)}"
+      if reason.nil? || reason.empty? || file.nil? || file.empty?
+        return tap_result
+      end
+      tap_result + format_failure_diagnostics(test_suite, test_case, reason, file)
     end
 
-    def format_pending_test(test_suite, test_case)
+    def format_pending_test(test_suite, test_case, device)
       increment_counter
-      "#{FAIL} #{counter} - #{test_case} # TODO Not written yet"
+      "#{FAIL} #{counter} - #{format_test_description(test_case, device)} # TODO Not written yet"
     end
 
     def format_test_summary(executed_message, failures_per_suite)
@@ -30,6 +33,14 @@ module XCPretty
     end
 
     private
+
+    def format_test_description(test_case, device)
+      if device.nil? || device.empty?
+        test_case
+      else
+        "#{test_case} on #{device}"
+      end
+    end
 
     def increment_counter
       @counter += 1

--- a/lib/xcpretty/formatters/tap.rb
+++ b/lib/xcpretty/formatters/tap.rb
@@ -39,7 +39,7 @@ module XCPretty
 
     def format_test_description(test_case, device)
       test_description = test_case
-      if device.nil? || device.empty?
+      if device.to_s.empty?
         test_case
       else
         "#{test_case} on #{device}"

--- a/lib/xcpretty/formatters/tap.rb
+++ b/lib/xcpretty/formatters/tap.rb
@@ -38,13 +38,11 @@ module XCPretty
     private
 
     def format_test_description(test_case, device)
-      test_description = test_case
       if device.to_s.empty?
         test_case
       else
         "#{test_case} on #{device}"
       end
-      test_description
     end
 
     def increment_counter

--- a/lib/xcpretty/formatters/tap.rb
+++ b/lib/xcpretty/formatters/tap.rb
@@ -16,16 +16,19 @@ module XCPretty
 
     def format_failing_test(test_suite, test_case, device, reason, file)
       increment_counter
-      tap_result = "#{FAIL} #{counter} - #{format_test_description(test_case, device)}"
+      test_description = format_test_description(test_case, device)
+      tap_result = "#{FAIL} #{counter} - #{test_description}"
       if reason.to_s.empty? || file.to_s.empty?
         return tap_result
       end
-      tap_result + format_failure_diagnostics(test_suite, test_case, reason, file)
+      tap_result +
+      format_failure_diagnostics(test_suite, test_case, reason, file)
     end
 
     def format_pending_test(test_suite, test_case, device)
       increment_counter
-      "#{FAIL} #{counter} - #{format_test_description(test_case, device)} # TODO Not written yet"
+      test_description = format_test_description(test_case, device)
+      "#{FAIL} #{counter} - #{test_description} # TODO Not written yet"
     end
 
     def format_test_summary(executed_message, failures_per_suite)
@@ -36,7 +39,11 @@ module XCPretty
 
     def format_test_description(test_case, device)
       test_description = test_case
-      test_description = "#{test_description} on #{device}" unless device.to_s.empty?
+      if device.nil? || device.empty?
+        test_case
+      else
+        "#{test_case} on #{device}"
+      end
       test_description
     end
 

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -114,9 +114,10 @@ module XCPretty
     UI_FAILING_TEST_MATCHER = /^\s{4}t = \s+\d+\.\d+s\s+Assertion Failure: (.*:\d+): (.*)$/
 
     # @regex Captured groups
-    # $1 = test_case
-    # $2 = device
-    PARALLEL_FAILING_TEST_MATCHER = /^\s*Test\s[Cc]ase\s'(?:.*)\.(.*)\(\)'\sfailed\son\s'(.*)'/
+    # $1 = test_suite
+    # $2 = test_case
+    # $3 = device
+    PARALLEL_FAILING_TEST_MATCHER = /^\s*Test\s[Cc]ase\s'(.*)\.(.*)\(\)'\sfailed\son\s'(.*)'/
 
     # @regex Captured groups
     # $1 = dsym
@@ -137,7 +138,7 @@ module XCPretty
     # $2 = test_case
     # $3 = device
     # $4 = time
-    TEST_CASE_PASSED_MATCHER = /^\s*Test [Cc]ase\s'(?:-\[(?:.*)\.)?(.*)(?:\s|\.)(.*)(?:\]|\(\))'\spassed\s(?:on\s'(.*)'\s)?\((\d*\.\d{3})\sseconds\)/
+    TEST_CASE_PASSED_MATCHER = /^\s*Test [Cc]ase\s'-?\[?(.*)(?:\s|\.)(.*)(?:\]|\(\))'\spassed\s(?:on\s'(.*)'\s)?\((\d*\.\d{3})\sseconds\)/
 
 
     # @regex Captured groups
@@ -149,7 +150,7 @@ module XCPretty
     # $1 = suite
     # $2 = test_case
     # $3 = device
-    TEST_CASE_PENDING_MATCHER = /^\s*Test [Cc]ase\s'(?:-\[(?:.*)\.)?(.*)(?:\s|\.)(.*)PENDING(?:\]|\(\))'\spassed\s(?:on\s'(.*)'\s)?/
+    TEST_CASE_PENDING_MATCHER = /^\s*Test [Cc]ase\s'-?\[?(.*)(?:\s|\.)(.*)PENDING(?:\]|\(\))'\spassed\s(?:on\s'(.*)'\s)?/
 
     # @regex Captured groups
     # $1 = suite
@@ -379,7 +380,7 @@ module XCPretty
       when UI_FAILING_TEST_MATCHER
         formatter.format_failing_test(@test_suite, @test_case, nil, $2, $1)
       when PARALLEL_FAILING_TEST_MATCHER
-        formatter.format_failing_test(@test_suite, $1, $2, nil, nil)
+        formatter.format_failing_test($1, $2, $3, nil, nil)
       when FAILING_TEST_MATCHER
         formatter.format_failing_test($2, $3, nil, $4, $1)
       when FATAL_ERROR_MATCHER

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -378,11 +378,11 @@ module XCPretty
       when EXECUTED_MATCHER
         format_summary_if_needed(text)
       when UI_FAILING_TEST_MATCHER
-        formatter.format_failing_test(@test_suite, @test_case, nil, $2, $1)
+        formatter.format_failing_device_test(@test_suite, @test_case, $2, $1, nil)
       when PARALLEL_FAILING_TEST_MATCHER
-        formatter.format_failing_test($1, $2, $3, nil, nil)
+        formatter.format_failing_device_test($1, $2, nil, nil, $3)
       when FAILING_TEST_MATCHER
-        formatter.format_failing_test($2, $3, nil, $4, $1)
+        formatter.format_failing_device_test($2, $3, $4, $1, nil)
       when FATAL_ERROR_MATCHER
         formatter.format_error($1)
       when FILE_MISSING_ERROR_MATCHER
@@ -402,9 +402,9 @@ module XCPretty
       when TEST_CASE_MEASURED_MATCHER
         formatter.format_measuring_test($1, $2, $3)
       when TEST_CASE_PENDING_MATCHER
-        formatter.format_pending_test($1, $2, $3)
+        formatter.format_pending_device_test($1, $2, $3)
       when TEST_CASE_PASSED_MATCHER
-        formatter.format_passing_test($1, $2, $3, $4)
+        formatter.format_passing_device_test($1, $2, $4, $3)
       when PODS_ERROR_MATCHER
         formatter.format_error($1)
       when PROCESS_INFO_PLIST_MATCHER
@@ -424,9 +424,9 @@ module XCPretty
       when TESTS_RUN_COMPLETION_MATCHER
         formatter.format_test_run_finished($1, $3)
       when TEST_SUITE_STARTED_MATCHER
-        formatter.format_test_run_started($1, $3)
+        formatter.format_device_test_run_started($1, $3)
       when TEST_SUITE_START_MATCHER
-        formatter.format_test_suite_started($1, $2)
+        formatter.format_device_test_suite_started($1, $2)
       when TIFFUTIL_MATCHER
         formatter.format_tiffutil($1)
       when TOUCH_MATCHER

--- a/lib/xcpretty/reporters/html.rb
+++ b/lib/xcpretty/reporters/html.rb
@@ -32,7 +32,8 @@ module XCPretty
     end
 
     def format_passing_test(suite, test_case, device, time)
-      add_test(suite, name: test_case, device: device, time: time, screenshots: [])
+      add_test(suite, name: test_case, device: device,
+                      time: time, screenshots: [])
     end
 
     private

--- a/lib/xcpretty/reporters/html.rb
+++ b/lib/xcpretty/reporters/html.rb
@@ -31,7 +31,7 @@ module XCPretty
                       screenshots: [])
     end
 
-    def format_passing_test(suite, test_case, time)
+    def format_passing_test(suite, test_case, device, time)
       add_test(suite, name: test_case, time: time, screenshots: [])
     end
 

--- a/lib/xcpretty/reporters/html.rb
+++ b/lib/xcpretty/reporters/html.rb
@@ -24,14 +24,14 @@ module XCPretty
       @parser.parse(line)
     end
 
-    def format_failing_test(suite, test_case, device, reason, file)
+    def format_failing_device_test(suite, test_case, reason, file, device)
       add_test(suite, name: test_case, failing: true,
                       reason: reason, file: file, device: device,
                       snippet: formatted_snippet(file),
                       screenshots: [])
     end
 
-    def format_passing_test(suite, test_case, device, time)
+    def format_passing_device_test(suite, test_case, time, device)
       add_test(suite, name: test_case, device: device,
                       time: time, screenshots: [])
     end

--- a/lib/xcpretty/reporters/html.rb
+++ b/lib/xcpretty/reporters/html.rb
@@ -24,20 +24,23 @@ module XCPretty
       @parser.parse(line)
     end
 
-    def format_failing_test(suite, test_case, reason, file)
+    def format_failing_test(suite, test_case, device, reason, file)
       add_test(suite, name: test_case, failing: true,
-                      reason: reason, file: file,
+                      reason: reason, file: file, device: device,
                       snippet: formatted_snippet(file),
                       screenshots: [])
     end
 
     def format_passing_test(suite, test_case, device, time)
-      add_test(suite, name: test_case, time: time, screenshots: [])
+      add_test(suite, name: test_case, device: device, time: time, screenshots: [])
     end
 
     private
 
     def formatted_snippet(filepath)
+      if filepath.to_s.empty?
+        return
+      end
       snippet = Snippet.from_filepath(filepath)
       Syntax.highlight_html(snippet)
     end

--- a/lib/xcpretty/reporters/json_compilation_database.rb
+++ b/lib/xcpretty/reporters/json_compilation_database.rb
@@ -14,7 +14,6 @@ module XCPretty
 
     def initialize(options)
       super(options)
-      puts options
       @compilation_units = []
       @pch_path = nil
       @current_file = nil

--- a/lib/xcpretty/reporters/json_compilation_database.rb
+++ b/lib/xcpretty/reporters/json_compilation_database.rb
@@ -14,6 +14,7 @@ module XCPretty
 
     def initialize(options)
       super(options)
+      puts options
       @compilation_units = []
       @pch_path = nil
       @current_file = nil

--- a/lib/xcpretty/reporters/junit.rb
+++ b/lib/xcpretty/reporters/junit.rb
@@ -52,10 +52,10 @@ module XCPretty
       test_node.attributes['classname'] = classname
       test_node.attributes['name']      = format_name(test_case, device)
       fail_node = test_node.add_element('failure')
-      if !reason.to_s.empty?
+      unless reason.to_s.empty?
         fail_node.attributes['message'] = reason
       end
-      if !file.to_s.empty?
+      unless file.to_s.empty?
         fail_node.text = file.sub(@directory + '/', '')
       end
       @test_count += 1

--- a/lib/xcpretty/reporters/junit.rb
+++ b/lib/xcpretty/reporters/junit.rb
@@ -27,33 +27,37 @@ module XCPretty
       @parser.parse(line)
     end
 
-    def format_test_run_started(name)
+    def format_test_run_started(name, device)
       @document.root.add_attribute('name', name)
     end
 
-    def format_passing_test(classname, test_case, time)
+    def format_passing_test(classname, test_case, device, time)
       test_node = suite(classname).add_element('testcase')
       test_node.attributes['classname'] = classname
-      test_node.attributes['name']      = test_case
+      test_node.attributes['name']      = format_name(test_case, device)
       test_node.attributes['time']      = time
       @test_count += 1
     end
 
-    def format_pending_test(classname, test_case)
+    def format_pending_test(classname, test_case, device)
       test_node = suite(classname).add_element('testcase')
       test_node.attributes['classname'] = classname
-      test_node.attributes['name']      = test_case
+      test_node.attributes['name']      = format_name(test_case, device)
       test_node.add_element('skipped')
       @test_count += 1
     end
 
-    def format_failing_test(classname, test_case, reason, file)
+    def format_failing_test(classname, test_case, device, reason, file)
       test_node = suite(classname).add_element('testcase')
       test_node.attributes['classname'] = classname
-      test_node.attributes['name']      = test_case
+      test_node.attributes['name']      = format_name(test_case, device)
       fail_node = test_node.add_element('failure')
-      fail_node.attributes['message'] = reason
-      fail_node.text = file.sub(@directory + '/', '')
+      if !reason.to_s.empty?
+        fail_node.attributes['message'] = reason
+      end
+      if !file.to_s.empty?
+        fail_node.text = file.sub(@directory + '/', '')
+      end
       @test_count += 1
       @fail_count += 1
     end
@@ -97,6 +101,16 @@ module XCPretty
       @test_count = 0
       @fail_count = 0
     end
+
+    def format_name(test_case, device)
+      if device.to_s.empty?
+        test_case
+      else
+        device_formatted = device.gsub(/[[:space:]]/, '')
+        "#{test_case}-#{device_formatted}"
+      end
+    end
+
   end
 end
 

--- a/lib/xcpretty/reporters/junit.rb
+++ b/lib/xcpretty/reporters/junit.rb
@@ -27,11 +27,11 @@ module XCPretty
       @parser.parse(line)
     end
 
-    def format_test_run_started(name, device)
+    def format_device_test_run_started(name, device)
       @document.root.add_attribute('name', name)
     end
 
-    def format_passing_test(classname, test_case, device, time)
+    def format_passing_device_test(classname, test_case, time, device)
       test_node = suite(classname).add_element('testcase')
       test_node.attributes['classname'] = classname
       test_node.attributes['name']      = format_name(test_case, device)
@@ -39,7 +39,7 @@ module XCPretty
       @test_count += 1
     end
 
-    def format_pending_test(classname, test_case, device)
+    def format_pending_device_test(classname, test_case, device)
       test_node = suite(classname).add_element('testcase')
       test_node.attributes['classname'] = classname
       test_node.attributes['name']      = format_name(test_case, device)
@@ -47,7 +47,7 @@ module XCPretty
       @test_count += 1
     end
 
-    def format_failing_test(classname, test_case, device, reason, file)
+    def format_failing_device_test(classname, test_case, reason, file, device)
       test_node = suite(classname).add_element('testcase')
       test_node.attributes['classname'] = classname
       test_node.attributes['name']      = format_name(test_case, device)

--- a/lib/xcpretty/reporters/reporter.rb
+++ b/lib/xcpretty/reporters/reporter.rb
@@ -34,12 +34,8 @@ module XCPretty
       @test_count += 1
       @fail_count += 1
       test_description = test_case
-      if !device.to_s.empty?
-        test_description = "#{test_description} on #{device}"
-      end
-      if !file.to_s.empty?
-        test_description = "#{test_description} in #{file}"
-      end
+      test_description = "#{test_description} on #{device}" unless device.to_s.empty?
+      test_description = "#{test_description} in #{file}" unless file.to_s.empty?
       if reason.to_s.empty?
         @tests.push("#{test_description} FAILED")
       else        
@@ -49,12 +45,16 @@ module XCPretty
 
     def format_passing_test(suite, test_case, device, time)
       @test_count += 1
-      @tests.push("#{test_case} PASSED")
+      test_description = test_case
+      test_description = "#{test_description} on #{device}" unless device.to_s.empty?
+      @tests.push("#{test_description} PASSED")
     end
 
     def format_pending_test(classname, test_case, device)
       @test_count += 1
-      @tests.push("#{test_case} IS PENDING")
+      test_description = test_case
+      test_description = "#{test_description} on #{device}" unless device.to_s.empty?
+      @tests.push("#{test_description} IS PENDING")
     end
 
     def write_report

--- a/lib/xcpretty/reporters/reporter.rb
+++ b/lib/xcpretty/reporters/reporter.rb
@@ -30,18 +30,29 @@ module XCPretty
       write_report
     end
 
-    def format_failing_test(suite, test_case, reason, file)
+    def format_failing_test(suite, test_case, device, reason, file)
       @test_count += 1
       @fail_count += 1
-      @tests.push("#{test_case} in #{file} FAILED: #{reason}")
+      test_description = test_case
+      if !device.to_s.empty?
+        test_description = "#{test_description} on #{device}"
+      end
+      if !file.to_s.empty?
+        test_description = "#{test_description} in #{file}"
+      end
+      if reason.to_s.empty?
+        @tests.push("#{test_description} FAILED")
+      else        
+        @tests.push("#{test_description} FAILED: #{reason}")
+      end
     end
 
-    def format_passing_test(suite, test_case, time)
+    def format_passing_test(suite, test_case, device, time)
       @test_count += 1
       @tests.push("#{test_case} PASSED")
     end
 
-    def format_pending_test(classname, test_case)
+    def format_pending_test(classname, test_case, device)
       @test_count += 1
       @tests.push("#{test_case} IS PENDING")
     end

--- a/lib/xcpretty/reporters/reporter.rb
+++ b/lib/xcpretty/reporters/reporter.rb
@@ -30,7 +30,7 @@ module XCPretty
       write_report
     end
 
-    def format_failing_test(suite, test_case, device, reason, file)
+    def format_failing_device_test(suite, test_case, reason, file, device)
       @test_count += 1
       @fail_count += 1
       test_description = test_case
@@ -47,7 +47,7 @@ module XCPretty
       end
     end
 
-    def format_passing_test(suite, test_case, device, time)
+    def format_passing_device_test(suite, test_case, time, device)
       @test_count += 1
       test_description = test_case
       unless device.to_s.empty?
@@ -56,7 +56,7 @@ module XCPretty
       @tests.push("#{test_description} PASSED")
     end
 
-    def format_pending_test(classname, test_case, device)
+    def format_pending_device_test(classname, test_case, device)
       @test_count += 1
       test_description = test_case
       unless device.to_s.empty?

--- a/lib/xcpretty/reporters/reporter.rb
+++ b/lib/xcpretty/reporters/reporter.rb
@@ -34,11 +34,15 @@ module XCPretty
       @test_count += 1
       @fail_count += 1
       test_description = test_case
-      test_description = "#{test_description} on #{device}" unless device.to_s.empty?
-      test_description = "#{test_description} in #{file}" unless file.to_s.empty?
+      unless device.to_s.empty?
+        test_description = "#{test_description} on #{device}"
+      end
+      unless file.to_s.empty?
+        test_description = "#{test_description} in #{file}"
+      end
       if reason.to_s.empty?
         @tests.push("#{test_description} FAILED")
-      else        
+      else
         @tests.push("#{test_description} FAILED: #{reason}")
       end
     end
@@ -46,14 +50,18 @@ module XCPretty
     def format_passing_test(suite, test_case, device, time)
       @test_count += 1
       test_description = test_case
-      test_description = "#{test_description} on #{device}" unless device.to_s.empty?
+      unless device.to_s.empty?
+        test_description = "#{test_description} on #{device}"
+      end
       @tests.push("#{test_description} PASSED")
     end
 
     def format_pending_test(classname, test_case, device)
       @test_count += 1
       test_description = test_case
-      test_description = "#{test_description} on #{device}" unless device.to_s.empty?
+      unless device.to_s.empty?
+        test_description = "#{test_description} on #{device}"
+      end
       @tests.push("#{test_description} IS PENDING")
     end
 

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -5,6 +5,7 @@ OCUNIT = 'ocunit'
 SAMPLE_OCUNIT_TEST_RUN_BEGINNING = "Test Suite '/Users/musalj/Library/Developer/Xcode/DerivedData/ReactiveCocoa-eznxkbqvgfsnrvetemqloysuwagb/Build/Products/Test/ReactiveCocoaTests.octest(Tests)' started at 2013-12-10 07:04:33 +0000"
 SAMPLE_KIWI_TEST_RUN_BEGINNING = "Test Suite 'ObjectiveRecordTests.xctest' started at 2013-12-10 06:15:39 +0000"
 SAMPLE_SPECTA_TEST_RUN_BEGINNING = "    Test Suite 'KIFTests.xctest' started at 2014-02-28 15:43:42 +0000"
+SAMPLE_PARALLEL_TEST_RUN_BEGINNING = "Test suite 'KIFTests.xctest' started on 'iPhone 8'"
 SAMPLE_OCUNIT_TEST_RUN_COMPLETION = "Test Suite '/Users/musalj/Library/Developer/Xcode/DerivedData/ReactiveCocoa-eznxkbqvgfsnrvetemqloysuwagb/Build/Products/Test/ReactiveCocoaTests.octest(Tests)' finished at 2013-12-10 07:03:03 +0000."
 SAMPLE_OCUNIT_FAILED_TEST_RUN_COMPLETION = "Test Suite '/Users/dm/someplace/Macadamia.octest' failed at 2014-09-24 23:09:20 +0000."
 SAMPLE_OCUNIT_PASSED_TEST_RUN_COMPLETION = "Test Suite 'Hazelnuts.xctest' passed at 2014-09-24 23:09:20 +0000."
@@ -13,9 +14,13 @@ SAMPLE_SPECTA_TEST_RUN_COMPLETION = "     Test Suite 'KIFTests.xctest' finished 
 
 SAMPLE_OCUNIT_SUITE_BEGINNING = "Test Suite 'RACKVOWrapperSpec' started at 2013-12-10 21:06:10 +0000"
 SAMPLE_SPECTA_SUITE_BEGINNING = "   Test Suite 'All tests' started at 2014-02-28 19:07:41 +0000"
+SAMPLE_PARALLEL_SUITE_BEGINNING = "Test suite 'All tests' started on 'iPhone 5s'"
 SAMPLE_KIWI_SUITE_COMPLETION = "Test Suite 'All tests' finished at 2013-12-08 04:26:49 +0000."
 SAMPLE_OCUNIT_SUITE_COMPLETION = "Test Suite '/Users/musalj/Library/Developer/Xcode/DerivedData/ReactiveCocoa-eznxkbqvgfsnrvetemqloysuwagb/Build/Products/Test/ReactiveCocoaTests.octest(Tests)' finished at 2013-12-08 22:09:37 +0000."
 SAMPLE_XCTEST_SUITE_COMPLETION = "Test Suite 'ObjectiveSugarTests.xctest' finished at 2013-12-09 04:42:13 +0000."
+
+SAMPLE_PASSING_DEVICE_TESTS = "Testing passed on 'iPhone 5s'"
+SAMPLE_FAILING_DEVICE_TESTS = "Testing failed on 'iPhone 6'"
 
 SAMPLE_UITEST_CASE_WITH_FAILURE = %Q(\
 Test Case '-[viewUITests.vmtAboutWindow testConnectToDesktop]' started.
@@ -70,6 +75,9 @@ SAMPLE_SLOWISH_TEST = "Test Case '-[RACCommandSpec enabled_signal_should_send_YE
 SAMPLE_SLOW_TEST = "Test Case '-[RACCommandSpec enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES]' passed (0.101 seconds)."
 SAMPLE_KIWI_TEST = "Test Case '-[MappingsTests Mappings_SupportsCreatingAParentObjectUsingJustIDFromTheServer]' passed (0.004 seconds)."
 SAMPLE_PENDING_KIWI_TEST = "Test Case '-[TAPIConversationSpec TAPIConversation_createConversation_SendsAPOSTRequestToTheConversationsEndpointPENDING]' passed (0.001 seconds)."
+SAMPLE_PASSING_PARALLEL_TEST = "Test case 'RACCommandSpec.enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES()' passed on 'iPhone 5s' (0.002 seconds)"
+SAMPLE_PENDING_PARALLEL_TEST = "Test case 'TAPIConversationSpec.TAPIConversation_createConversation_SendsAPOSTRequestToTheConversationsEndpointPENDING()' passed on 'iPhone 5s' (0.002 seconds)"
+SAMPLE_FAILING_PARALLEL_TEST = "Test case 'SKWelcomeActivationViewControllerSpecSpec.SKWelcomeActivationViewController_When_a_user_enters_their_details_lets_them_enter_a_valid_manager_code()' failed on 'iPhone 6' (6.274 seconds)"
 SAMPLE_MEASURING_TEST = "<unknown>:0: Test Case '-[SecEncodeTransformTests.SecEncodeTransformTests test_RFC4648_Decode_UsingBase32]' measured [Time, seconds] average: 0.013, relative standard deviation: 26.773%, values: [0.023838, 0.012034, 0.013512, 0.011022, 0.011203, 0.012814, 0.011131, 0.012740, 0.013646, 0.012145], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100"
 SAMPLE_COMPILE = %Q(
 CompileC /Users/musalj/Library/Developer/Xcode/DerivedData/ObjectiveSugar-ayzdhqmmwtqgysdpznmovjlupqjy/Build/Intermediates/Pods.build/Debug-iphonesimulator/Pods-ObjectiveSugar.build/Objects-normal/i386/NSMutableArray+ObjectiveSugar.o /Users/musalj/code/OSS/ObjectiveSugar/Classes/NSMutableArray+ObjectiveSugar.m normal i386 objective-c com.apple.compilers.llvm.clang.1_0.compiler

--- a/spec/fixtures/custom_reporter.rb
+++ b/spec/fixtures/custom_reporter.rb
@@ -1,18 +1,18 @@
 # encoding: utf-8
 class DogeReporter < XCPretty::Reporter
 
-  def format_failing_test(suite, test_case, reason, file)
+  def format_failing_test(suite, test_case, device, reason, file)
     @test_count += 1
     @fail_count += 1
     @tests.push("WOW such FAIL. Many #{test_case}. Much #{reason}. Very #{file}.")
   end
 
-  def format_passing_test(suite, test_case, time)
+  def format_passing_test(suite, test_case, device, time)
     @test_count += 1
     @tests.push("WOW such PASS. Many #{test_case}. Much green. Very success.")
   end
 
-  def format_pending_test(classname, test_case)
+  def format_pending_test(classname, test_case, device)
     @test_count += 1
     @tests.push("WOW such PENDING. Many #{test_case}. Much stop. Very wait.")
   end

--- a/spec/fixtures/custom_reporter.rb
+++ b/spec/fixtures/custom_reporter.rb
@@ -1,18 +1,18 @@
 # encoding: utf-8
 class DogeReporter < XCPretty::Reporter
 
-  def format_failing_test(suite, test_case, device, reason, file)
+  def format_failing_device_test(suite, test_case, reason, file, device)
     @test_count += 1
     @fail_count += 1
     @tests.push("WOW such FAIL. Many #{test_case}. Much #{reason}. Very #{file}.")
   end
 
-  def format_passing_test(suite, test_case, device, time)
+  def format_passing_device_test(suite, test_case, time, device)
     @test_count += 1
     @tests.push("WOW such PASS. Many #{test_case}. Much green. Very success.")
   end
 
-  def format_pending_test(classname, test_case, device)
+  def format_pending_device_test(classname, test_case, device)
     @test_count += 1
     @tests.push("WOW such PENDING. Many #{test_case}. Much stop. Very wait.")
   end

--- a/spec/xcpretty/formatters/rspec_spec.rb
+++ b/spec/xcpretty/formatters/rspec_spec.rb
@@ -17,16 +17,16 @@ module XCPretty
     context "without colors" do
 
       it "prints dots for passing tests" do
-        @formatter.format_passing_test("sweez testz", "sample spec", "iPhone X", "0.002").should == "."
+        @formatter.format_passing_device_test("sweez testz", "sample spec", "0.002", "iPhone X").should == "."
       end
 
       it "prints P for pending tests" do
-        @formatter.format_pending_test("sweez testz", "iPhone X", "sample spec").should == "P"
+        @formatter.format_pending_device_test("sweez testz", "sample spec", "iPhone X").should == "P"
       end
 
       it "prints F for failing tests" do
-        @formatter.format_failing_test(
-          "///file", "NSNumber Specs", "adding numbers", nil, "should add 2 numbers"
+        @formatter.format_failing_device_test(
+          "///file", "NSNumber Specs", "adding numbers", "should add 2 numbers", nil
         ).should == "F"
       end
     end
@@ -36,18 +36,18 @@ module XCPretty
       before { @formatter.colorize = true }
 
       it "prints green for passing tests" do
-        @formatter.format_passing_test("sweez testz", "sample spec", "iPhone X", "0.002"
+        @formatter.format_passing_device_test("sweez testz", "sample spec", "0.002", "iPhone X"
         ).should be_colored :green
       end
 
       it "prints yellow for pending tests" do
-        @formatter.format_pending_test("sweez testz", "iPhone X", "sample spec"
+        @formatter.format_pending_device_test("sweez testz", "sample spec", "iPhone X"
         ).should be_colored :yellow
       end
 
       it "prints red for failing tests" do
-        @formatter.format_failing_test(
-          "///file", "NSNumber Specs", "adding numbers", nil, "should add 2 numbers"
+        @formatter.format_failing_device_test(
+          "///file", "NSNumber Specs", "adding numbers", "should add 2 numbers", nil
         ).should be_colored :red
       end
     end

--- a/spec/xcpretty/formatters/rspec_spec.rb
+++ b/spec/xcpretty/formatters/rspec_spec.rb
@@ -17,16 +17,16 @@ module XCPretty
     context "without colors" do
 
       it "prints dots for passing tests" do
-        @formatter.format_passing_test("sweez testz", "sample spec", "0.002").should == "."
+        @formatter.format_passing_test("sweez testz", "sample spec", "iPhone X", "0.002").should == "."
       end
 
       it "prints P for pending tests" do
-        @formatter.format_pending_test("sweez testz", "sample spec").should == "P"
+        @formatter.format_pending_test("sweez testz", "iPhone X", "sample spec").should == "P"
       end
 
       it "prints F for failing tests" do
         @formatter.format_failing_test(
-          "///file", "NSNumber Specs", "adding numbers", "should add 2 numbers"
+          "///file", "NSNumber Specs", "adding numbers", nil, "should add 2 numbers"
         ).should == "F"
       end
     end
@@ -36,18 +36,18 @@ module XCPretty
       before { @formatter.colorize = true }
 
       it "prints green for passing tests" do
-        @formatter.format_passing_test("sweez testz", "sample spec", "0.002"
+        @formatter.format_passing_test("sweez testz", "sample spec", "iPhone X", "0.002"
         ).should be_colored :green
       end
 
       it "prints yellow for pending tests" do
-        @formatter.format_pending_test("sweez testz", "sample spec"
+        @formatter.format_pending_test("sweez testz", "iPhone X", "sample spec"
         ).should be_colored :yellow
       end
 
       it "prints red for failing tests" do
         @formatter.format_failing_test(
-          "///file", "NSNumber Specs", "adding numbers", "should add 2 numbers"
+          "///file", "NSNumber Specs", "adding numbers", nil, "should add 2 numbers"
         ).should be_colored :red
       end
     end

--- a/spec/xcpretty/formatters/simple_spec.rb
+++ b/spec/xcpretty/formatters/simple_spec.rb
@@ -96,18 +96,33 @@ module XCPretty
       end
 
       it "formats failing tests" do
-        @formatter.format_failing_test("RACCommandSpec", "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES", "expected: 1, got: 0", 'path/to/file').should ==
+        @formatter.format_failing_test("RACCommandSpec", "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES", nil, "expected: 1, got: 0", 'path/to/file').should ==
         "    x enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES, expected: 1, got: 0"
       end
 
+      it "formats failing parallel tests" do
+        @formatter.format_failing_test("RACCommandSpec", "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES", "iPhone X", nil, nil).should ==
+        "    x enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES (iPhone X)"
+      end
+
       it "formats passing tests" do
-        @formatter.format_passing_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "0.001").should ==
+        @formatter.format_passing_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", nil, "0.001").should ==
         "    . _tupleByAddingObject__should_add_a_non_nil_object (0.001 seconds)"
       end
 
+      it "formats passing parallel tests" do
+        @formatter.format_passing_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "iPhone X", "0.001").should ==
+        "    . _tupleByAddingObject__should_add_a_non_nil_object (iPhone X) (0.001 seconds)"
+      end
+
       it "formats pending tests" do
-        @formatter.format_pending_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object").should ==
+        @formatter.format_pending_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", nil).should ==
         "    P _tupleByAddingObject__should_add_a_non_nil_object [PENDING]"
+      end
+
+      it "formats pending parallel tests" do
+        @formatter.format_pending_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "iPhone X").should ==
+        "    P _tupleByAddingObject__should_add_a_non_nil_object (iPhone X) [PENDING]"
       end
 
       it "formats measuring tests" do
@@ -149,13 +164,23 @@ module XCPretty
       end
 
       it "formats test run start" do
-        @formatter.format_test_run_started("ReactiveCocoaTests.octest(Tests)").should ==
+        @formatter.format_test_run_started("ReactiveCocoaTests.octest(Tests)", nil).should ==
         "Test Suite ReactiveCocoaTests.octest(Tests) started"
       end
 
+      it "formats parallel test run start" do
+        @formatter.format_test_run_started("ReactiveCocoaTests.octest(Tests)", "iPhone X").should ==
+        "Test Suite ReactiveCocoaTests.octest(Tests) started (iPhone X)"
+      end
+
       it "formats tests suite started" do
-        @formatter.format_test_suite_started("RACKVOWrapperSpec").should ==
+        @formatter.format_test_suite_started("RACKVOWrapperSpec", nil).should ==
         "RACKVOWrapperSpec"
+      end
+
+      it "formats parallel tests suite started" do
+        @formatter.format_test_suite_started("RACKVOWrapperSpec", "iPhone X").should ==
+        "RACKVOWrapperSpec (iPhone X)"
       end
 
       it "formats Touch" do

--- a/spec/xcpretty/formatters/simple_spec.rb
+++ b/spec/xcpretty/formatters/simple_spec.rb
@@ -96,32 +96,32 @@ module XCPretty
       end
 
       it "formats failing tests" do
-        @formatter.format_failing_test("RACCommandSpec", "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES", nil, "expected: 1, got: 0", 'path/to/file').should ==
+        @formatter.format_failing_device_test("RACCommandSpec", "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES", "expected: 1, got: 0", 'path/to/file', nil).should ==
         "    x enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES, expected: 1, got: 0"
       end
 
       it "formats failing parallel tests" do
-        @formatter.format_failing_test("RACCommandSpec", "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES", "iPhone X", nil, nil).should ==
+        @formatter.format_failing_device_test("RACCommandSpec", "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES", nil, nil, "iPhone X").should ==
         "    x enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES (iPhone X)"
       end
 
       it "formats passing tests" do
-        @formatter.format_passing_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", nil, "0.001").should ==
+        @formatter.format_passing_device_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "0.001", nil).should ==
         "    . _tupleByAddingObject__should_add_a_non_nil_object (0.001 seconds)"
       end
 
       it "formats passing parallel tests" do
-        @formatter.format_passing_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "iPhone X", "0.001").should ==
+        @formatter.format_passing_device_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "0.001", "iPhone X").should ==
         "    . _tupleByAddingObject__should_add_a_non_nil_object (iPhone X) (0.001 seconds)"
       end
 
       it "formats pending tests" do
-        @formatter.format_pending_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", nil).should ==
+        @formatter.format_pending_device_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", nil).should ==
         "    P _tupleByAddingObject__should_add_a_non_nil_object [PENDING]"
       end
 
       it "formats pending parallel tests" do
-        @formatter.format_pending_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "iPhone X").should ==
+        @formatter.format_pending_device_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "iPhone X").should ==
         "    P _tupleByAddingObject__should_add_a_non_nil_object (iPhone X) [PENDING]"
       end
 
@@ -164,22 +164,22 @@ module XCPretty
       end
 
       it "formats test run start" do
-        @formatter.format_test_run_started("ReactiveCocoaTests.octest(Tests)", nil).should ==
+        @formatter.format_device_test_run_started("ReactiveCocoaTests.octest(Tests)", nil).should ==
         "Test Suite ReactiveCocoaTests.octest(Tests) started"
       end
 
       it "formats parallel test run start" do
-        @formatter.format_test_run_started("ReactiveCocoaTests.octest(Tests)", "iPhone X").should ==
+        @formatter.format_device_test_run_started("ReactiveCocoaTests.octest(Tests)", "iPhone X").should ==
         "Test Suite ReactiveCocoaTests.octest(Tests) started (iPhone X)"
       end
 
       it "formats tests suite started" do
-        @formatter.format_test_suite_started("RACKVOWrapperSpec", nil).should ==
+        @formatter.format_device_test_suite_started("RACKVOWrapperSpec", nil).should ==
         "RACKVOWrapperSpec"
       end
 
       it "formats parallel tests suite started" do
-        @formatter.format_test_suite_started("RACKVOWrapperSpec", "iPhone X").should ==
+        @formatter.format_device_test_suite_started("RACKVOWrapperSpec", "iPhone X").should ==
         "RACKVOWrapperSpec (iPhone X)"
       end
 

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -169,31 +169,31 @@ module XCPretty
     end
 
     it "parses uitest failing tests" do
-      @formatter.should receive(:format_failing_test).with(
+      @formatter.should receive(:format_failing_device_test).with(
         "viewUITests.vmtAboutWindow",
         "testConnectToDesktop",
-        nil,
         "UI Testing Failure - Unable to find hit point for element Button 0x608001165880: {{74.0, -54.0}, {44.0, 38.0}}, label: 'Disconnect'",
-        "<unknown>:0"
+        "<unknown>:0",
+        nil
       )
       @parser.parse(SAMPLE_UITEST_CASE_WITH_FAILURE)
     end
 
     it "parses specta failing tests" do
-      @formatter.should receive(:format_failing_test).with("SKWelcomeViewControllerSpecSpec",
+      @formatter.should receive(:format_failing_device_test).with("SKWelcomeViewControllerSpecSpec",
                                                            "SKWelcomeViewController_When_a_user_opens_the_app_from_a_clean_installation_displays_the_welcome_screen",
-                                                           nil,
                                                            "The step timed out after 2.00 seconds: Failed to find accessibility element with the label \"The asimplest way to make smarter business decisions\"",
-                                                           "/Users/vickeryj/Code/ipad-register/KIFTests/Specs/SKWelcomeViewControllerSpec.m:11")
+                                                           "/Users/vickeryj/Code/ipad-register/KIFTests/Specs/SKWelcomeViewControllerSpec.m:11",
+                                                           nil)
       @parser.parse(SAMPLE_SPECTA_FAILURE)
     end
 
     it "parses old specta failing tests" do
-      @formatter.should receive(:format_failing_test).with("RACCommandSpec",
+      @formatter.should receive(:format_failing_device_test).with("RACCommandSpec",
                                                            "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES",
-                                                           nil,
                                                            "expected: 1, got: 0",
-                                                           "/Users/musalj/code/OSS/ReactiveCocoa/ReactiveCocoaFramework/ReactiveCocoaTests/RACCommandSpec.m:458")
+                                                           "/Users/musalj/code/OSS/ReactiveCocoa/ReactiveCocoaFramework/ReactiveCocoaTests/RACCommandSpec.m:458",
+                                                           nil)
       @parser.parse(SAMPLE_OLD_SPECTA_FAILURE)
     end
 
@@ -203,48 +203,47 @@ module XCPretty
     end
 
     it "parses passing ocunit tests" do
-      @formatter.should receive(:format_passing_test).with('RACCommandSpec',
-                                                           'enabled_signal_should_send_YES_while_executing_is_YES',
-                                                           nil,
-                                                           '0.001')
+      @formatter.should receive(:format_passing_device_test).with('RACCommandSpec',
+                                                                  'enabled_signal_should_send_YES_while_executing_is_YES',
+                                                                  '0.001',
+                                                                   nil)
       @parser.parse(SAMPLE_OCUNIT_TEST)
     end
 
     it "parses passing specta tests" do
-      @formatter.should receive(:format_passing_test).with('SKWelcomeActivationViewControllerSpecSpec',
-                                                           'SKWelcomeActivationViewController_When_a_user_enters_their_details_lets_them_enter_a_valid_manager_code',
-                                                           nil,
-                                                           '0.725')
+      @formatter.should receive(:format_passing_device_test).with('SKWelcomeActivationViewControllerSpecSpec',
+                                                                  'SKWelcomeActivationViewController_When_a_user_enters_their_details_lets_them_enter_a_valid_manager_code',
+                                                                  '0.725',
+                                                                  nil)
       @parser.parse(SAMPLE_SPECTA_TEST)
     end
 
     it "parses pending tests" do
-      @formatter.should receive(:format_pending_test).with('TAPIConversationSpec',
-                                                           'TAPIConversation_createConversation_SendsAPOSTRequestToTheConversationsEndpoint',
-                                                           nil)
+      @formatter.should receive(:format_pending_device_test).with('TAPIConversationSpec',
+                                                                  'TAPIConversation_createConversation_SendsAPOSTRequestToTheConversationsEndpoint',
+                                                                   nil)
       @parser.parse(SAMPLE_PENDING_KIWI_TEST)
     end
 
     it "parses passing parallel tests" do
-      @formatter.should receive(:format_passing_test).with('RACCommandSpec',
+      @formatter.should receive(:format_passing_device_test).with('RACCommandSpec',
                                                            'enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES',
-                                                           'iPhone 5s',
-                                                           '0.002')
+                                                           '0.002',
+                                                           'iPhone 5s')
       @parser.parse(SAMPLE_PASSING_PARALLEL_TEST)
     end
 
     it "parses pending parallel tests" do
-      @formatter.should receive(:format_pending_test).with('TAPIConversationSpec',
-                                                           'TAPIConversation_createConversation_SendsAPOSTRequestToTheConversationsEndpoint',
-                                                           'iPhone 5s')
+      @formatter.should receive(:format_pending_device_test).with('TAPIConversationSpec',
+                                                                  'TAPIConversation_createConversation_SendsAPOSTRequestToTheConversationsEndpoint',
+                                                                  'iPhone 5s')
       @parser.parse(SAMPLE_PENDING_PARALLEL_TEST)
     end
 
     it "parses failing parallel tests" do
-      @formatter.should receive(:format_failing_test).with('SKWelcomeActivationViewControllerSpecSpec',
+      @formatter.should receive(:format_failing_device_test).with('SKWelcomeActivationViewControllerSpecSpec',
                                                            'SKWelcomeActivationViewController_When_a_user_enters_their_details_lets_them_enter_a_valid_manager_code',
-                                                           'iPhone 6',
-                                                           nil, nil)
+                                                           nil, nil, 'iPhone 6')
       @parser.parse(SAMPLE_FAILING_PARALLEL_TEST)
     end
 
@@ -371,32 +370,32 @@ module XCPretty
     end
 
     it "parses ocunit test run started" do
-      @formatter.should receive(:format_test_run_started).with('ReactiveCocoaTests.octest(Tests)', nil)
+      @formatter.should receive(:format_device_test_run_started).with('ReactiveCocoaTests.octest(Tests)', nil)
       @parser.parse(SAMPLE_OCUNIT_TEST_RUN_BEGINNING)
     end
 
     it "parses specta test run started" do
-      @formatter.should receive(:format_test_run_started).with('KIFTests.xctest', nil)
+      @formatter.should receive(:format_device_test_run_started).with('KIFTests.xctest', nil)
       @parser.parse(SAMPLE_SPECTA_TEST_RUN_BEGINNING)
     end
 
     it "parses parallel test run started" do
-      @formatter.should_receive(:format_test_run_started).with('KIFTests.xctest', 'iPhone 8')
+      @formatter.should_receive(:format_device_test_run_started).with('KIFTests.xctest', 'iPhone 8')
       @parser.parse(SAMPLE_PARALLEL_TEST_RUN_BEGINNING)
     end
 
     it "parses ocunit test suite started" do
-      @formatter.should receive(:format_test_suite_started).with('RACKVOWrapperSpec', nil)
+      @formatter.should receive(:format_device_test_suite_started).with('RACKVOWrapperSpec', nil)
       @parser.parse(SAMPLE_OCUNIT_SUITE_BEGINNING)
     end
 
     it "parses specta test suite started" do
-      @formatter.should receive(:format_test_suite_started).with('All tests', nil)
+      @formatter.should receive(:format_device_test_suite_started).with('All tests', nil)
       @parser.parse(SAMPLE_SPECTA_SUITE_BEGINNING)
     end
 
     it "parses parallel test suite started" do
-      @formatter.should receive(:format_test_suite_started).with('All tests', 'iPhone 5s')
+      @formatter.should receive(:format_device_test_suite_started).with('All tests', 'iPhone 5s')
       @parser.parse(SAMPLE_PARALLEL_SUITE_BEGINNING)
     end
 

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -172,6 +172,7 @@ module XCPretty
       @formatter.should receive(:format_failing_test).with(
         "viewUITests.vmtAboutWindow",
         "testConnectToDesktop",
+        nil,
         "UI Testing Failure - Unable to find hit point for element Button 0x608001165880: {{74.0, -54.0}, {44.0, 38.0}}, label: 'Disconnect'",
         "<unknown>:0"
       )
@@ -181,6 +182,7 @@ module XCPretty
     it "parses specta failing tests" do
       @formatter.should receive(:format_failing_test).with("SKWelcomeViewControllerSpecSpec",
                                                            "SKWelcomeViewController_When_a_user_opens_the_app_from_a_clean_installation_displays_the_welcome_screen",
+                                                           nil,
                                                            "The step timed out after 2.00 seconds: Failed to find accessibility element with the label \"The asimplest way to make smarter business decisions\"",
                                                            "/Users/vickeryj/Code/ipad-register/KIFTests/Specs/SKWelcomeViewControllerSpec.m:11")
       @parser.parse(SAMPLE_SPECTA_FAILURE)
@@ -189,6 +191,7 @@ module XCPretty
     it "parses old specta failing tests" do
       @formatter.should receive(:format_failing_test).with("RACCommandSpec",
                                                            "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES",
+                                                           nil,
                                                            "expected: 1, got: 0",
                                                            "/Users/musalj/code/OSS/ReactiveCocoa/ReactiveCocoaFramework/ReactiveCocoaTests/RACCommandSpec.m:458")
       @parser.parse(SAMPLE_OLD_SPECTA_FAILURE)
@@ -202,6 +205,7 @@ module XCPretty
     it "parses passing ocunit tests" do
       @formatter.should receive(:format_passing_test).with('RACCommandSpec',
                                                            'enabled_signal_should_send_YES_while_executing_is_YES',
+                                                           nil,
                                                            '0.001')
       @parser.parse(SAMPLE_OCUNIT_TEST)
     end
@@ -209,14 +213,39 @@ module XCPretty
     it "parses passing specta tests" do
       @formatter.should receive(:format_passing_test).with('SKWelcomeActivationViewControllerSpecSpec',
                                                            'SKWelcomeActivationViewController_When_a_user_enters_their_details_lets_them_enter_a_valid_manager_code',
+                                                           nil,
                                                            '0.725')
       @parser.parse(SAMPLE_SPECTA_TEST)
     end
 
     it "parses pending tests" do
       @formatter.should receive(:format_pending_test).with('TAPIConversationSpec',
-                                                           'TAPIConversation_createConversation_SendsAPOSTRequestToTheConversationsEndpoint')
+                                                           'TAPIConversation_createConversation_SendsAPOSTRequestToTheConversationsEndpoint',
+                                                           nil)
       @parser.parse(SAMPLE_PENDING_KIWI_TEST)
+    end
+
+    it "parses passing parallel tests" do
+      @formatter.should receive(:format_passing_test).with('RACCommandSpec',
+                                                           'enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES',
+                                                           'iPhone 5s',
+                                                           '0.002')
+      @parser.parse(SAMPLE_PASSING_PARALLEL_TEST)
+    end
+
+    it "parses pending parallel tests" do
+      @formatter.should receive(:format_pending_test).with('TAPIConversationSpec',
+                                                           'TAPIConversation_createConversation_SendsAPOSTRequestToTheConversationsEndpoint',
+                                                           'iPhone 5s')
+      @parser.parse(SAMPLE_PENDING_PARALLEL_TEST)
+    end
+
+    it "parses failing parallel tests" do
+      @formatter.should receive(:format_failing_test).with('SKWelcomeActivationViewControllerSpecSpec',
+                                                           'SKWelcomeActivationViewController_When_a_user_enters_their_details_lets_them_enter_a_valid_manager_code',
+                                                           'iPhone 6',
+                                                           nil, nil)
+      @parser.parse(SAMPLE_FAILING_PARALLEL_TEST)
     end
 
     it 'parses measuring tests' do
@@ -342,23 +371,43 @@ module XCPretty
     end
 
     it "parses ocunit test run started" do
-      @formatter.should receive(:format_test_run_started).with('ReactiveCocoaTests.octest(Tests)')
+      @formatter.should receive(:format_test_run_started).with('ReactiveCocoaTests.octest(Tests)', nil)
       @parser.parse(SAMPLE_OCUNIT_TEST_RUN_BEGINNING)
     end
 
     it "parses specta test run started" do
-      @formatter.should receive(:format_test_run_started).with('KIFTests.xctest')
+      @formatter.should receive(:format_test_run_started).with('KIFTests.xctest', nil)
       @parser.parse(SAMPLE_SPECTA_TEST_RUN_BEGINNING)
     end
 
+    it "parses parallel test run started" do
+      @formatter.should_receive(:format_test_run_started).with('KIFTests.xctest', 'iPhone 8')
+      @parser.parse(SAMPLE_PARALLEL_TEST_RUN_BEGINNING)
+    end
+
     it "parses ocunit test suite started" do
-      @formatter.should receive(:format_test_suite_started).with('RACKVOWrapperSpec')
+      @formatter.should receive(:format_test_suite_started).with('RACKVOWrapperSpec', nil)
       @parser.parse(SAMPLE_OCUNIT_SUITE_BEGINNING)
     end
 
     it "parses specta test suite started" do
-      @formatter.should receive(:format_test_suite_started).with('All tests')
+      @formatter.should receive(:format_test_suite_started).with('All tests', nil)
       @parser.parse(SAMPLE_SPECTA_SUITE_BEGINNING)
+    end
+
+    it "parses parallel test suite started" do
+      @formatter.should receive(:format_test_suite_started).with('All tests', 'iPhone 5s')
+      @parser.parse(SAMPLE_PARALLEL_SUITE_BEGINNING)
+    end
+
+    it "parses passed device tests" do
+      @formatter.should_receive(:format_device_tests_passed).with('iPhone 5s')
+      @parser.parse(SAMPLE_PASSING_DEVICE_TESTS)
+    end
+
+    it "parses failing device tests" do
+      @formatter.should_receive(:format_device_tests_failed).with('iPhone 6')
+      @parser.parse(SAMPLE_FAILING_DEVICE_TESTS)
     end
 
     context "errors" do

--- a/spec/xcpretty/reporters/junit_spec.rb
+++ b/spec/xcpretty/reporters/junit_spec.rb
@@ -10,7 +10,7 @@ module XCPretty
 
     it "has name attribute in root node" do
       test_name = "ReactiveCocoaTests.xctest"
-      @formatter.format_test_run_started(test_name, nil)
+      @formatter.format_device_test_run_started(test_name, nil)
       @formatter.finish
       document = REXML::Document.new(@reporter_file)
       document.root.attributes['name'].should == test_name

--- a/spec/xcpretty/reporters/junit_spec.rb
+++ b/spec/xcpretty/reporters/junit_spec.rb
@@ -10,7 +10,7 @@ module XCPretty
 
     it "has name attribute in root node" do
       test_name = "ReactiveCocoaTests.xctest"
-      @formatter.format_test_run_started(test_name)
+      @formatter.format_test_run_started(test_name, nil)
       @formatter.finish
       document = REXML::Document.new(@reporter_file)
       document.root.attributes['name'].should == test_name

--- a/spec/xcpretty/reporters/reporter_spec.rb
+++ b/spec/xcpretty/reporters/reporter_spec.rb
@@ -12,22 +12,37 @@ module XCPretty
     end
 
     it "reports a passing test" do
-      @reporter.format_passing_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "0.001")
+      @reporter.format_passing_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", nil, "0.001")
       @reporter.tests.should include("_tupleByAddingObject__should_add_a_non_nil_object PASSED")
     end
 
+    it "reports a passing parallel test" do
+      @reporter.format_passing_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "iPhone X", "0.001")
+      @reporter.tests.should include("_tupleByAddingObject__should_add_a_non_nil_object on iPhone X PASSED")
+    end
+
     it "reports a failing test" do
-      @reporter.format_failing_test("RACCommandSpec", "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES", "expected: 1, got: 0", 'path/to/file')
+      @reporter.format_failing_test("RACCommandSpec", "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES", nil, "expected: 1, got: 0", 'path/to/file')
       @reporter.tests.should include("enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES in path/to/file FAILED: expected: 1, got: 0")
     end
 
+    it "reports a failing parallel test" do
+      @reporter.format_failing_test("RACCommandSpec", "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES", "iPhone X", nil, nil)
+      @reporter.tests.should include("enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES on iPhone X FAILED")
+    end
+
     it "reports a pending test" do
-      @reporter.format_pending_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object")
+      @reporter.format_pending_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", nil)
       @reporter.tests.should include("_tupleByAddingObject__should_add_a_non_nil_object IS PENDING")
     end
 
+    it "reports a pending parallel test" do
+      @reporter.format_pending_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "iPhone X")
+      @reporter.tests.should include("_tupleByAddingObject__should_add_a_non_nil_object on iPhone X IS PENDING")
+    end
+
     it "writes to disk" do
-      @reporter.format_passing_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "0.001")
+      @reporter.format_passing_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", nil, "0.001")
       file = double("file stub")
       File.should_receive(:open).with("example_file", "w").and_yield(file)
       file.should_receive(:write).with("_tupleByAddingObject__should_add_a_non_nil_object PASSED\nFINISHED RUNNING 1 TESTS WITH 0 FAILURES")

--- a/spec/xcpretty/reporters/reporter_spec.rb
+++ b/spec/xcpretty/reporters/reporter_spec.rb
@@ -12,37 +12,37 @@ module XCPretty
     end
 
     it "reports a passing test" do
-      @reporter.format_passing_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", nil, "0.001")
+      @reporter.format_passing_device_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "0.001", nil)
       @reporter.tests.should include("_tupleByAddingObject__should_add_a_non_nil_object PASSED")
     end
 
     it "reports a passing parallel test" do
-      @reporter.format_passing_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "iPhone X", "0.001")
+      @reporter.format_passing_device_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "0.001", "iPhone X")
       @reporter.tests.should include("_tupleByAddingObject__should_add_a_non_nil_object on iPhone X PASSED")
     end
 
     it "reports a failing test" do
-      @reporter.format_failing_test("RACCommandSpec", "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES", nil, "expected: 1, got: 0", 'path/to/file')
+      @reporter.format_failing_device_test("RACCommandSpec", "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES", "expected: 1, got: 0", 'path/to/file', nil)
       @reporter.tests.should include("enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES in path/to/file FAILED: expected: 1, got: 0")
     end
 
     it "reports a failing parallel test" do
-      @reporter.format_failing_test("RACCommandSpec", "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES", "iPhone X", nil, nil)
+      @reporter.format_failing_device_test("RACCommandSpec", "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES", nil, nil, "iPhone X")
       @reporter.tests.should include("enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES on iPhone X FAILED")
     end
 
     it "reports a pending test" do
-      @reporter.format_pending_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", nil)
+      @reporter.format_pending_device_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", nil)
       @reporter.tests.should include("_tupleByAddingObject__should_add_a_non_nil_object IS PENDING")
     end
 
     it "reports a pending parallel test" do
-      @reporter.format_pending_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "iPhone X")
+      @reporter.format_pending_device_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "iPhone X")
       @reporter.tests.should include("_tupleByAddingObject__should_add_a_non_nil_object on iPhone X IS PENDING")
     end
 
     it "writes to disk" do
-      @reporter.format_passing_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", nil, "0.001")
+      @reporter.format_passing_device_test("RACCommandSpec", "_tupleByAddingObject__should_add_a_non_nil_object", "0.001", nil)
       file = double("file stub")
       File.should_receive(:open).with("example_file", "w").and_yield(file)
       file.should_receive(:write).with("_tupleByAddingObject__should_add_a_non_nil_object PASSED\nFINISHED RUNNING 1 TESTS WITH 0 FAILURES")


### PR DESCRIPTION
## Description

These are my proposed changes to fix #295. Due to [significant changes in test output](https://github.com/supermarin/xcpretty/issues/295#issuecomment-334308992) when adding multiple destinations, the platform needs to change to support current and future versions of Xcode. Whether or not my proposed changes make it in, this at least a first-stab approach.

Note that this focuses only on test output; I have not yet noticed any discrepancies in other `xcodebuild` buildactions.

## Implementation

- Deprecated existing `Formatter` test formatting methods in favor of methods that accept an optional `device` (custom reporters should see deprecation warnings)
- Updated all formatters and reporters to use new methods
- Updated `Parser` regex constants to also parse Swift output + device name, if it exists
- Fixed existing unit and BDD tests
- Added unit tests for parsing parallel test output

## For Discussion

Whether or not this solution is accepted or iterated, the actual device output formatting from all of the formatters and reporters is still up for debate. For example, I chose the unused `cyan` method within `ansi.rb` for devices within `simple.rb`, but I'm not sure if the color is reserved for other use.

## Testing

- [x] Ran `rake spec`
- [x] Ran `rake cucumber`
- [x] Ran `rake lint`