### PR TITLE
Further improve code sign error checking

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -227,7 +227,7 @@ module XCPretty
 
       # @regex Captured groups
       # $1 = whole error
-      CHECK_DEPENDENCIES_ERRORS_MATCHER = /^(Code\s?Sign error:.*|Code signing is required for product type .* in SDK .*|No profile matching .* found:.*|Provisioning profile .* doesn't .*|Swift is unavailable on .*|.?Use Legacy Swift Language Version.*)$/
+      CHECK_DEPENDENCIES_ERRORS_MATCHER = /^(Code\s?Sign(ing)? error:.*|Code signing is required for product type .* in SDK .*|No profile matching .* found:.*|Provisioning profile .* doesn't .*|Swift is unavailable on .*|.?Use Legacy Swift Language Version.*)$/i
 
       # @regex Captured groups
       # $1 = whole error

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -602,6 +602,10 @@ SAMPLE_CODESIGN_ERROR = %Q(
 Code Sign error: No code signing identites found: No valid signing identities (i.e. certificate and private key pair) matching the team ID ‚ÄúCAT6HF57NJ‚Äù were found.
 )
 
+SAMPLE_CODESIGN_NEWER_XCODE_ERROR = %Q(
+Code Signing Error: Signing certificate is invalid. Signing certificate "iPhone Distribution: Nick de la Hunt (6BT8K489FY)", serial number "37A0162FDCA15F37", is not valid for code signing. It may have been revoked or expired.
+)
+
 SAMPLE_CODESIGN_ERROR_NO_SPACES = %Q(
 CodeSign error: code signing is required for product type 'Application' in SDK 'iOS 7.0'
 )

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -452,6 +452,13 @@ module XCPretty
         @parser.parse(SAMPLE_CODESIGN_ERROR)
       end
 
+      it "parses code sign error for newer xcode versions:" do
+        @formatter.should receive(:format_error).with(
+          'Code Signing Error: Signing certificate is invalid. Signing certificate "iPhone Distribution: Nick de la Hunt (6BT8K489FY)", serial number "37A0162FDCA15F37", is not valid for code signing. It may have been revoked or expired.'
+        )
+        @parser.parse(SAMPLE_CODESIGN_NEWER_XCODE_ERROR)
+      end
+
       it "parses CodeSign error: (no spaces)" do
         @formatter.should receive(:format_error).with(
           "CodeSign error: code signing is required for product type 'Application' in SDK 'iOS 7.0'"


### PR DESCRIPTION
Xcode 8.1 and above throws a slightly different error message. Modify code to improve error handling.

Prior to Xcode 8.1 the errors looked like this:
```
Code Sign error: No code signing identites found: No valid signing identities (i.e. certificate and private key pair) matching the team ID Some id were found.
```

Newer versions, however throw:
```
=== BUILD TARGET MyApp OF PROJECT MyApp WITH CONFIGURATION Debug ===

Check dependencies
Code Signing Error: Signing certificate is invalid. Signing certificate "iPhone Distribution: Some name (XXXXXXX)", serial number "XXXXXXXXXXXXXXX", is not valid for code signing. It may have been revoked or expired.
Code Signing Error: Code signing is required for product type 'Application' in SDK 'iOS 11.0'
```


Ping @supermarin for thoughts on this