### PR TITLE
Fix index for screenshots in HTML report

### DIFF
--- a/assets/report.html.erb
+++ b/assets/report.html.erb
@@ -153,8 +153,8 @@
                     <% if !test[:screenshots].empty? %>
                       <section class="test-detail">
                         <% test[:screenshots].each_with_index do |screenshot, idx| %>
-                          <a href="javascript:toggleScreenshot('<%=test[:name] %>', <%=index %>)">
-                            <img class="screenshot" id="screenshot-<%=test[:name] %>-<%=index %>" src="<%=screenshot %>" />
+                          <a href="javascript:toggleScreenshot('<%=test[:name] %>', <%=idx %>)">
+                            <img class="screenshot" id="screenshot-<%=test[:name] %>-<%=idx %>" src="<%=screenshot %>" />
                           </a>
                         <% end %>
                       </section>


### PR DESCRIPTION
The enlarging of screenshots does not work correctly if there were more screenshots taken in one test. Opening any screenshot will enlarge the first one, since wrong index (which is always zero) is used.

This PR should fix the issue.

I am not sure how to test the template, since this is JS and HTML issue so writing simple behavior test would be pretty hard.

![Illustrative image](https://user-images.githubusercontent.com/708312/48268570-9a6c7980-e435-11e8-9c8b-a227d22e48e5.png)