### PR TITLE
Upgrade rouge

### DIFF
--- a/xcpretty.gemspec
+++ b/xcpretty.gemspec
@@ -26,9 +26,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rouge', '~> 2.0.7'
+  spec.add_dependency 'rouge', '~> 3.28.0'
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rubocop", "~> 0.34.0"
   spec.add_development_dependency "rspec", "2.99.0"


### PR DESCRIPTION
closes https://github.com/xcpretty/xcpretty/issues/339

I upgraded rouge to latest version.

All checks passed locally:
```
$ bundle exec rake spec
$ bundle exec rake cucumber
$ bundle exec rake lint
```