### PR TITLE
Add ERB package in gemspec for FAILING_TEST_MATCHER

### DIFF
--- a/xcpretty.gemspec
+++ b/xcpretty.gemspec
@@ -33,5 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 0.34.0"
   spec.add_development_dependency "rspec", "2.99.0"
   spec.add_development_dependency "cucumber", "~> 1.0"
+  spec.add_development_dependency "erb", "2.2.0"
 end
 


### PR DESCRIPTION
`FAILING_TEST_MATCHER` requires the `ERB` package, which is not included in the gemspec, to be installed. When this case is encountered, the following error occurred:
```
/opt/homebrew/lib/ruby/gems/3.3.0/gems/xcpretty-0.4.0/lib/xcpretty/parser.rb:366:in `parse': uninitialized constant XCPretty::Parser::ERB (NameError)

        formatter.format_failing_test($2, $3, ERB::Util.html_escape($4), $1)
                                              ^^^
	from /opt/homebrew/lib/ruby/gems/3.3.0/gems/xcpretty-0.4.0/lib/xcpretty/formatters/formatter.rb:88:in `pretty_format'
	from /opt/homebrew/lib/ruby/gems/3.3.0/gems/xcpretty-0.4.0/lib/xcpretty/printer.rb:19:in `pretty_print'
	from /opt/homebrew/lib/ruby/gems/3.3.0/gems/xcpretty-0.4.0/bin/xcpretty:84:in `block in <top (required)>'
	from /opt/homebrew/lib/ruby/gems/3.3.0/gems/xcpretty-0.4.0/bin/xcpretty:83:in `each_line'
	from /opt/homebrew/lib/ruby/gems/3.3.0/gems/xcpretty-0.4.0/bin/xcpretty:83:in `<top (required)>'
	from /opt/homebrew/lib/ruby/gems/3.3.0/bin/xcpretty:25:in `load'
	from /opt/homebrew/lib/ruby/gems/3.3.0/bin/xcpretty:25:in `<main>'
```

Sorry I didn't write a test for this change, but want to see quickly if such an import should be necessary.

Link to the pipeline: https://github.com/mozilla-mobile/firefox-ios/actions/runs/12401742699/job/34621859867 (See "Run tests" step)