### PR TITLE
Fix uninitialized constant XCPretty::Parser::ERB crash

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -299,7 +299,15 @@ module XCPretty
 
     attr_reader :formatter
 
+    def load_dependencies
+      unless @@loaded ||= false
+        require 'erb'
+        @@loaded = true
+      end
+    end
+
     def initialize(formatter)
+      load_dependencies
       @formatter = formatter
     end
 


### PR DESCRIPTION
## Description

Fixes #391.

Introduced by 16a96b71 in #313.

<h2 id="testing-steps">Testing steps</h2>

- Add
  ```ruby
  gem 'xcpretty', git: 'https://github.com/revolter/xcpretty', branch: 'fix/uninitialized-constant-erb'
  ```
  to your `Gemfile`.
- Run
  ```sh
  bundle install
  ```